### PR TITLE
Restructure datum cloud docs (alternative layout)

### DIFF
--- a/guide/datum-cloud-operator/quick-start.md
+++ b/guide/datum-cloud-operator/quick-start.md
@@ -1,5 +1,3 @@
-# Quick Start Guide for Datum Cloud Operator Development
-
 - [Summary](#summary)
 - [Prerequisites](#prerequisites)
   - [Troubleshooting](#troubleshooting)
@@ -16,6 +14,9 @@
   - [Registering a Location](#registering-a-location)
   - [Creating a Network](#creating-a-network)
   - [Creating a Workload](#creating-a-workload)
+    - [Check the state of the workload](#check-the-state-of-the-workload)
+    - [Check Workload Deployments](#check-workload-deployments)
+    - [Check Instances](#check-instances)
 
 ## Summary
 

--- a/guide/introduction.md
+++ b/guide/introduction.md
@@ -1,3 +1,0 @@
-# Welcome to Datum
-
-This guide is designed to help you get started with Datum.

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -9,8 +9,12 @@
     "guides": [{
             "name": "Guide",
             "sidebar": [{
-                "path": "guide/introduction.md",
-                "type": "page"
+                "name": "Datum Cloud Operator",
+                "type": "folder",
+                "children": [{
+                    "path": "guide/datum-cloud-operator/quick-start.md",
+                    "type": "page"
+                }]
             }]
         },
         {


### PR DESCRIPTION
This provides an alternative structure for the docs "Quick Start", there is a screenshot of how this looks below.

<img width="1459" alt="Screenshot 2024-12-12 at 9 44 28 AM" src="https://github.com/user-attachments/assets/6aed54d4-3d78-4351-9ae8-72a2f88d87c9" />
