### PR TITLE
feat: add documentation on connecting to the API

### DIFF
--- a/content/en/docs/api/_index.md
+++ b/content/en/docs/api/_index.md
@@ -1,0 +1,16 @@
+---
+title: Datum Cloud API
+draft: false
+---
+
+Datum Cloud provides a declarative API platform to create the infrastructure
+necessary to deploy and manage services with advanced networking capabilities.
+Many of our APIs are exposed through a Kubernetes API as [Custom Resources]
+enabling you to use much of the tooling available within the Kubernetes
+ecosystem to interact with our API.
+
+[Custom Resources]:
+    https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
+
+Continue reading the guides below to understand how to connect and interact with
+the Datum Cloud API.

--- a/content/en/docs/api/authenticating.md
+++ b/content/en/docs/api/authenticating.md
@@ -10,7 +10,7 @@ Access Token in the Datum Cloud Portal and using the
 the Personal Access Token for a short-lived bearer token.
 
 ```shell
-▶ curl https://api.staging.env.datum.net/datum-os/oauth/token/exchange \
+▶ curl https://api.datum.net/datum-os/oauth/token/exchange \
    -H "Authorization: Bearer $PAT" -sS | jq
 {
   "access_token": "[[redacted]]",

--- a/content/en/docs/api/authenticating.md
+++ b/content/en/docs/api/authenticating.md
@@ -1,0 +1,45 @@
+---
+title: Authenticating
+draft: false
+---
+
+The Datum Cloud platform supports users authenticating with the API with
+short-lived Bearer tokens. Bearer tokens can be created by creating a Personal
+Access Token in the Datum Cloud Portal and using the
+`https://api.datum.net/datum-os/oauth/token/exchange` API endpoint to exchange
+the Personal Access Token for a short-lived bearer token.
+
+```shell
+▶ curl https://api.staging.env.datum.net/datum-os/oauth/token/exchange \
+   -H "Authorization: Bearer $PAT" -sS | jq
+{
+  "access_token": "[[redacted]]",
+  "token_type": "Bearer"
+}
+```
+
+Use the returned API token to authenticate with the [Datum Cloud control
+planes](./connecting-to-the-api.md). The token should be refreshed every hour.
+
+{{% alert title="Tip" color="info" %}}
+Use `datumctl auth get-token` command to quickly grab a short-lived
+access token that can be used to authenticate with the Datum Cloud API.
+{{% /alert %}}
+
+## Authentication Errors
+
+Invalid authentication tokens or unauthorized requests will result in the same
+**403 Forbidden** error.
+
+```
+{
+  "kind": "Status",
+  "apiVersion": "v1",
+  "metadata": {},
+  "status": "Failure",
+  "message": "forbidden: User \"system:anonymous\" cannot get path \"/openapi/v3\"",
+  "reason": "Forbidden",
+  "details": {},
+  "code": 403
+}
+```

--- a/content/en/docs/api/connecting-to-the-api.md
+++ b/content/en/docs/api/connecting-to-the-api.md
@@ -33,7 +33,7 @@ Most users will interact with a project control plane to manage resources.
 The following base URL can be used to access an organization's control plane:
 
 ```url
-https://api.datum.net/apis/resourcemanager.datumapis.com/v1alpha/organizations/{organization-id}/control-plane
+https://api.datum.net/apis/resourcemanager.datumapis.com/v1alpha/organizations/{organization_id}/control-plane
 ```
 
 ### Project Control Plane
@@ -43,7 +43,7 @@ plane created to manage resources. Use the following base URL to access a
 project's control plane:
 
 ```url
-https://api.datum.net/apis/resourcemanager.datumapis.com/v1alpha/projects/{project-id}/control-plane
+https://api.datum.net/apis/resourcemanager.datumapis.com/v1alpha/projects/{project_id}/control-plane
 ```
 
 ## API Discovery
@@ -54,7 +54,7 @@ example that demonstrates some services available in an organization's control
 plane.
 
 ```shell
-$ curl -sS 'https://api.datum.net/apis/resourcemanager.datumapis.com/v1alpha/organizations/{organization-id}/control-plane/openapi/v3' \
+$ curl -sS 'https://api.datum.net/apis/resourcemanager.datumapis.com/v1alpha/organizations/{organization_id}/control-plane/openapi/v3' \
    -H "Authorization: Bearer $(datumctl auth get-token)"
 
 {

--- a/content/en/docs/api/connecting-to-the-api.md
+++ b/content/en/docs/api/connecting-to-the-api.md
@@ -1,0 +1,74 @@
+---
+title: Connecting to the API
+draft: false
+---
+
+The Datum Cloud platform is comprised of multiple control planes that users can
+interact with to manage their organization's resources.
+
+## Control Planes
+
+A control plane is the central component responsible for managing and
+reconciling resources within the system. It continuously monitors the declared
+state of customer-defined configurations and ensures that the actual system
+state aligns with those definitions.
+
+The Datum Cloud control plane acts as the authoritative source of truth,
+processing API requests, validating configurations, and coordinating underlying
+infrastructure changes. It maintains resource consistency by detecting
+deviations and automatically applying corrective actions.
+
+There are two primary control planes that users will interact with to manage the
+resources deployed within their organization.
+
+- **Organizational Control Plane** - Manages resources that are attached to the
+  organizational resource (e.g. Projects)
+- **Project Control Plane** - Manages resources that make up an Organization's
+  project
+
+Most users will interact with a project control plane to manage resources.
+
+### Organization Control Plane
+
+The following base URL can be used to access an organization's control plane:
+
+```url
+https://api.datum.net/apis/resourcemanager.datumapis.com/v1alpha/organizations/{organization-id}/control-plane
+```
+
+### Project Control Plane
+
+Projects created in an organization's control plane will have their own control
+plane created to manage resources. Use the following base URL to access a
+project's control plane:
+
+```url
+https://api.datum.net/apis/resourcemanager.datumapis.com/v1alpha/projects/{project-id}/control-plane
+```
+
+## API Discovery
+
+Every control plane exports the APIs available in the control plane by exporting
+an OpenAPI for each service at the `/openapi/v3` URL. For example, here's an
+example that demonstrates some services available in an organization's control
+plane.
+
+```shell
+$ curl -sS 'https://api.datum.net/apis/resourcemanager.datumapis.com/v1alpha/organizations/{organization-id}/control-plane/openapi/v3' \
+   -H "Authorization: Bearer $(datumctl auth get-token)"
+
+{
+  "paths": {
+    "apis/resourcemanager.datumapis.com/v1alpha": {
+      "serverRelativeURL": "/openapi/v3/apis/resourcemanager.datumapis.com/v1alpha?hash=D0A1DF465E973D5C8FC30D065B864272955A66C14609154E7EAECC0426C71E99F3982ECBA4D5C6C92EC3DF497E159F2129D0F8A20CDC8E5746583D1BFEA80A52"
+    },
+  ]
+}
+```
+
+{{% alert title="Tip" color="info" %}}
+The above command expects you've [setup the Datum CLI](../tasks/tools.md)
+{{% /alert %}}
+
+The URL provided in the response can be used to retrieve the OpenAPI v3 spec for
+the service.


### PR DESCRIPTION
Adds documentation on how to connect to the API control planes available to users of the Datum Cloud platform. 

Closes: #17 