### PR TITLE
feat: simplify project creation

### DIFF
--- a/content/en/docs/tasks/create-project/_index.md
+++ b/content/en/docs/tasks/create-project/_index.md
@@ -40,8 +40,6 @@ kind: Project
 metadata:
   generateName: intro-project-
 spec:
-  parent:
-    external: //resourcemanager.datumapis.com/organizations/RESOURCE_ID
 ```
 
 Create the project


### PR DESCRIPTION
We're propagating the organization ID as part of the control plane URL which allows us to automatically fill out the required spec information. Users don't need to provide this option directly anymore.