### PR TITLE
Resources Documentation

### DIFF
--- a/content/en/docs/api/locations.md
+++ b/content/en/docs/api/locations.md
@@ -1,0 +1,73 @@
+---
+title: Locations
+description: Locations are where Datum workloads run. They define the geographical and cloud provider context for your workloads.
+---
+
+### Example Location Definition
+
+This is an example of a location that specifies a GCP region (us-central1) and a
+city code (DFW for Dallas Fort Worth):
+
+```yaml
+apiVersion: compute.datumapis.com/v1alpha
+kind: Location
+metadata:
+  name: my-gcp-us-south1-a
+spec:
+  locationClassName: datum-managed
+  topology:
+    topology.datum.net/city-code: DFW
+  provider:
+    gcp:
+      projectId: my-gcp-project
+      region: us-south1
+      zone: us-south1-a
+```
+
+### Location Components
+
+Let's walk through the sample spec and review each of the key components.
+
+* The name of the location.
+
+```yaml
+name: my-gcp-us-south1-a
+```
+
+* The `locationClassName` field specifies the class of the location. In this
+case, it's set to `datum-managed`, indicating that this location is managed by
+Datum. Alternately, it can be set to `self-managed` for users who have deployed
+their own self-managed Datum control-plane.
+
+```yaml
+locationClassName: datum-managed
+```
+
+* The `topology` field is used to specify which Datum mangaed network to connect
+to. Currently Datum offers the following City locations:
+
+  * `DFW` (Dallas Fort Worth, Texas, USA)
+  * `LHR` (Heathrow, London, England)
+  * `DLS` (Dalles, Oregon, USA)
+
+```yaml
+topology:
+  topology.datum.net/city-code: DFW
+```
+
+* The `provider` section is where you tell it which cloud provider to use to
+deploy your workload. For the GCP cloud provider, you specify the project ID,
+region, and zone.
+
+```yaml
+provider:
+  gcp:
+    projectId: my-gcp-project
+    region: us-south1
+    zone: us-south1-a
+```
+
+### Detailed API Specification
+
+For a complete API specification of the Location resource, refer to the
+[Detailed Reference](https://github.com/datum-cloud/network-services-operator/blob/main/docs/api/locations.md).

--- a/content/en/docs/api/networks.md
+++ b/content/en/docs/api/networks.md
@@ -1,0 +1,58 @@
+---
+title: Networks
+description: Networks are essential for deploying workloads in Datum. They define how workloads communicate.
+---
+
+### Networks Overview
+
+When deploying workloads in Datum, networks are used to define the IP Address
+Management of the workloads.
+
+### Getting Started with Networks
+
+Most workloads can use the default network configuration shown below. This
+configuration leverages Datum's built-in IP Address Management (IPAM) to
+automatically handle IP address assignment.
+
+```yaml
+apiVersion: networking.datumapis.com/v1alpha
+kind: Network
+metadata:
+  name: default
+spec:
+  ipam:
+    mode: Auto
+```
+
+### IP Address Management (IPAM)
+
+Datum's automatic IPAM mode simplifies network management by eliminating
+the need to manually configure IP addresses for each workload.
+
+**Default Auto Configuration:**
+
+```yaml
+spec:
+  ipam:
+    mode: Auto
+```
+
+In Auto mode, Datum uses the following default IP address ranges:
+
+- **IPv4 Ranges**: `10.128.0.0/9`
+- **IPv6 Ranges**: A /48 allocated from `fd20::/20`
+
+### Customizing IP Address Ranges
+
+You can override the default IP ranges by specifying custom ranges in your
+network manifest.
+
+```yaml
+spec:
+  ipam:
+    mode: Auto
+    ipv4Ranges:
+      - 172.17.0.0/16
+    ipv6Ranges:
+      - fd20:1234:5678::/48
+```

--- a/content/en/docs/api/networks.md
+++ b/content/en/docs/api/networks.md
@@ -56,3 +56,8 @@ spec:
     ipv6Ranges:
       - fd20:1234:5678::/48
 ```
+
+### Detailed API Specification
+
+For a complete API specification of the Location resource, refer to the
+[Detailed Reference](https://github.com/datum-cloud/network-services-operator/blob/main/docs/api/networks.md).

--- a/content/en/docs/api/resources.md
+++ b/content/en/docs/api/resources.md
@@ -1,0 +1,132 @@
+---
+title: Glossary of Resources
+draft: false
+---
+
+There are many resources available in the Datum Cloud API that can be used to manage
+your infrastructure. This document provides an overview oxf the available
+resources and how to use them.
+
+## Export Policies
+
+[Detailed Export Policies API Reference](https://github.com/datum-cloud/telemetry-services-operator/blob/main/docs/api/exportpolicies.md)
+
+[Sample Export Policy](https://github.com/datum-cloud/telemetry-services-operator/blob/main/config/samples/telemetry_v1alpha1_exportpolicy.yaml)
+
+{{< tabpane heade"Sample Export Policy">}}
+{{% tab header="Simple Example" text=true %}}
+
+```yaml
+apiVersion: telemetry.datum.net/v1alpha1
+kind: ExportPolicy
+metadata:
+  name: my-export-policy
+spec:
+
+  exportPolicyClassName: datum-managed
+  topology:
+    topology.datum.net/city-code: DFW
+  provider:
+    gcp:
+      projectId: GCP_PROJECT_ID
+      region: us-south1
+      zone: us-south1-a
+```
+
+{{% /tab %}}
+{{% tab header="Detailed Example With Comments" text=true %}}
+
+```yaml
+apiVersion: telemetry.datumapis.com/v1alpha1
+kind: ExportPolicy
+metadata:
+  name: exportpolicy-sample
+spec:
+
+# Defines the telemetry sources that should be exported. An export policy can
+# define multiple telemetry sources. Telemetry data will **not** be de-duped if
+# its selected from multiple sources
+
+  sources:
+    - name: "telemetry-metrics"  # Descriptive name for the source
+      # Source metrics from the Datum Cloud platform
+      metrics:
+        # The options in this section are expected to be mutually exclusive. Users
+        # can either leverage metricsql or resource selectors.
+        #
+        # This option allows user to supply a metricsql query if they're already
+        # familiar with using metricsql queries to select metric data from
+        # Victoria Metrics.
+        metricsql: |
+          {service_name="telemetry.datumapis.com"}
+  sinks:
+    - name: grafana-cloud-metrics
+      sources:
+        - telemetry-metrics
+      target:
+        prometheusRemoteWrite:
+          endpoint: "https://prometheus-prod-56-prod-us-east-2.grafana.net/api/prom/push"
+          authentication:
+            basicAuth:
+              secretRef:
+                name: "grafana-cloud-credentials"
+          batch:
+            timeout: 5s     # Batch timeout before sending telemetry
+            maxSize: 500    # Maximum number of telemetry entries per batch
+          retry:
+            maxAttempts: 3  # Maximum retry attempts
+            backoffDuration: 2s     # Delay between retry attempts
+```
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+## Instances
+
+[Detailed Instances API Reference](https://github.com/datum-cloud/workload-operator/blob/main/docs/api/instances.md)
+
+Instances are what a workload creates.
+
+Let's say you create a workload to run a container and set the location to
+a GCP region. Datum's workload operator will create a GCP virtual machine in
+that region and run the container on it. The GCP virtual machine is the instance.
+
+## Locations
+
+[Detailed Locations API Reference](https://github.com/datum-cloud/network-services-operator/blob/main/docs/api/locations.md)
+
+## Networks
+
+[Detailed Networks API Reference](https://github.com/datum-cloud/network-services-operator/blob/main/docs/api/networks.md)
+
+## Network Bindings
+
+[Detailed Network Bindings API Reference](https://github.com/datum-cloud/network-services-operator/blob/main/docs/api/networkbindings.md)
+
+## Network Contexts
+
+[Detailed Network Contexts API Reference](https://github.com/datum-cloud/network-services-operator/blob/main/docs/api/networkcontexts.md)
+
+## Network Policies
+
+[Detailed Network Policies API Reference](https://github.com/datum-cloud/network-services-operator/blob/main/docs/api/networkpolicies.md)
+
+## Projects
+
+[Detailed Projects API Reference](https://github.com/datum-cloud/datum/blob/milo-apiserver/docs/api/resourcemanager.datumapis.com_projects.yaml.md)
+
+## Subnet Claims
+
+[Detailed Subnet Claims API Reference](https://github.com/datum-cloud/network-services-operator/blob/main/docs/api/subnetclaims.md)
+
+## Subnets
+
+[Detailed Subnets API Reference](https://github.com/datum-cloud/network-services-operator/blob/main/docs/api/subnets.md)
+
+## Workload
+
+[Detailed Workload API Reference](https://github.com/datum-cloud/workload-operator/blob/main/docs/api/workloads.md)
+
+## Workload Deployments
+
+[Detailed Workload Deployments API Reference](https://github.com/datum-cloud/workload-operator/blob/main/docs/api/workloaddeployments.md)

--- a/content/en/docs/api/resources.md
+++ b/content/en/docs/api/resources.md
@@ -4,7 +4,7 @@ draft: false
 ---
 
 There are many resources available in the Datum Cloud API that can be used to manage
-your infrastructure. This document provides an overview oxf the available
+your infrastructure. This document provides an overview of the available
 resources and how to use them.
 
 ## Export Policies

--- a/content/en/docs/api/resources.md
+++ b/content/en/docs/api/resources.md
@@ -11,26 +11,46 @@ resources and how to use them.
 
 [Detailed Export Policies API Reference](https://github.com/datum-cloud/telemetry-services-operator/blob/main/docs/api/exportpolicies.md)
 
-[Sample Export Policy](https://github.com/datum-cloud/telemetry-services-operator/blob/main/config/samples/telemetry_v1alpha1_exportpolicy.yaml)
-
 {{< tabpane heade"Sample Export Policy">}}
-{{% tab header="Simple Example" text=true %}}
+{{% tab header="Grafana Cloud Example" text=true %}}
 
 ```yaml
-apiVersion: telemetry.datum.net/v1alpha1
-kind: ExportPolicy
-metadata:
-  name: my-export-policy
-spec:
-
-  exportPolicyClassName: datum-managed
-  topology:
-    topology.datum.net/city-code: DFW
-  provider:
-    gcp:
-      projectId: GCP_PROJECT_ID
-      region: us-south1
-      zone: us-south1-a
+apiVersion: v1
+items:
+- apiVersion: telemetry.datumapis.com/v1alpha1
+  kind: ExportPolicy
+  metadata:
+    name: exportpolicy
+  spec:
+    sinks:
+    - name: grafana-cloud-metrics
+      sources:
+      - telemetry-metrics
+      - gateway-metrics
+      target:
+        prometheusRemoteWrite:
+          authentication:
+            basicAuth:
+              secretRef:
+                name: grafana-cloud-credentials
+          batch:
+            maxSize: 500
+            timeout: 5s
+          endpoint: https://prometheus-prod-56-prod-us-east-2.grafana.net/api/prom/push
+          retry:
+            backoffDuration: 2s
+            maxAttempts: 3
+    sources:
+    - metrics:
+        metricsql: |
+          {service_name="telemetry.datumapis.com"}
+      name: telemetry-metrics
+    - metrics:
+        metricsql: |
+          {service_name="gateway.networking.k8s.io"}
+      name: gateway-metrics
+kind: List
+metadata: {}
 ```
 
 {{% /tab %}}
@@ -95,9 +115,66 @@ that region and run the container on it. The GCP virtual machine is the instance
 
 [Detailed Locations API Reference](https://github.com/datum-cloud/network-services-operator/blob/main/docs/api/locations.md)
 
+{{< tabpane heade"Sample Locations">}}
+{{% tab header="GCP" text=true %}}
+
+```yaml
+apiVersion: networking.datumapis.com/v1alpha
+kind: Location
+metadata:
+ name: gcp-us-west1-a
+spec:
+  locationClassName: datum-managed
+  topology:
+    topology.datum.net/city-code: DLS
+  provider:
+    gcp:
+      projectId: datum-cloud-poc-1
+      region: us-west1
+      zone: us-west1-a
+```
+
+{{% /tab %}}
+{{< /tabpane >}}
+
 ## Networks
 
 [Detailed Networks API Reference](https://github.com/datum-cloud/network-services-operator/blob/main/docs/api/networks.md)
+
+{{< tabpane heade"Sample Network">}}
+{{% tab header="Simple Network" text=true %}}
+
+```yaml
+apiVersion: networking.datumapis.com/v1alpha
+kind: Network
+metadata:
+  name: default
+spec:
+  ipam:
+    mode: Auto
+```
+
+{{% /tab %}}
+{{% tab header="Custom IP Ranges" text=true %}}
+
+```yaml
+apiVersion: networking.datumapis.com/v1alpha
+kind: Network
+metadata:
+  name: default
+spec:
+  ipam:
+    mode: Auto
+    ipv4Ranges:
+      - 172.17.0.0/16
+    ipv6Ranges:
+      - fd20:1234:5678::/48
+
+```
+
+{{% /tab %}}
+
+{{< /tabpane >}}
 
 ## Network Bindings
 
@@ -114,6 +191,18 @@ that region and run the container on it. The GCP virtual machine is the instance
 ## Projects
 
 [Detailed Projects API Reference](https://github.com/datum-cloud/datum/blob/milo-apiserver/docs/api/resourcemanager.datumapis.com_projects.yaml.md)
+{{< tabpane>}}
+{{% tab header="Sample Project" text=true %}}
+
+```apiVersion: resourcemanager.datumapis.com/v1alpha
+kind: Project
+metadata:
+  generateName: sample-project-
+spec:
+```
+
+{{% /tab %}}
+{{< /tabpane >}}
 
 ## Subnet Claims
 
@@ -126,6 +215,170 @@ that region and run the container on it. The GCP virtual machine is the instance
 ## Workload
 
 [Detailed Workload API Reference](https://github.com/datum-cloud/workload-operator/blob/main/docs/api/workloads.md)
+{{< tabpane heade"Sample Workload">}}
+{{% tab header="Container Sample" text=true %}}
+
+```yaml
+apiVersion: compute.datumapis.com/v1alpha
+kind: Workload
+metadata:
+  labels:
+    tier: app
+  name: workload-sandbox-sample
+spec:
+  template:
+    metadata:
+      labels:
+        tier: app
+    spec:
+      runtime:
+        resources:
+          instanceType: datumcloud/d1-standard-2
+        sandbox:
+          containers:
+            - name: netdata
+              image: docker.io/netdata/netdata:latest
+              volumeAttachments:
+                - name: secret
+                  mountPath: /secret
+                - name: configmap
+                  mountPath: /configmap
+      networkInterfaces:
+      - network:
+          name: default
+        networkPolicy:
+          ingress:
+            - ports:
+              - port: 19999
+              - port: 22
+              from:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+      volumes:
+      - name: secret
+        secret:
+          secretName: workload-sandbox-sample-secret
+      - name: configmap
+        configMap:
+          name: workload-sandbox-sample-configmap
+  placements:
+  - name: us
+    cityCodes:
+    - DFW
+    scaleSettings:
+      minReplicas: 1
+```
+
+{{% /tab %}}
+{{% tab header="Container with Multiple Placements" text=true %}}
+
+```yaml
+apiVersion: compute.datumapis.com/v1alpha
+kind: Workload
+metadata:
+  labels:
+    tier: app
+  name: workload-sample
+spec:
+  template:
+    metadata:
+      labels:
+        tier: app
+    spec:
+      runtime:
+        resources:
+          instanceType: datumcloud/d1-standard-2
+        sandbox:
+          containers:
+            - name: netdata
+              image: docker.io/netdata/netdata:latest
+      networkInterfaces:
+      - network:
+          name: default
+        networkPolicy:
+          ingress:
+            - ports:
+              - port: 19999
+              from:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+  placements:
+  - name: us-south
+    cityCodes:
+    - DFW
+    scaleSettings:
+      minReplicas: 1
+  - name: us-south2
+    cityCodes:
+    - DFW
+    scaleSettings:
+      minReplicas: 1
+```
+
+{{% /tab %}}
+{{% tab header="VM Sample" text=true %}}
+
+```yaml
+apiVersion: compute.datumapis.com/v1alpha
+kind: Workload
+metadata:
+  labels:
+    tier: app
+  name: workload-vm-sample
+spec:
+  template:
+    metadata:
+      annotations:
+        compute.datumapis.com/ssh-keys: |
+          myuser:ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAqyjfr0gTk1lxqA/eEac0djYWuw+ZLFphPHmfWwxbO5 joshlreese@gmail.com
+      labels:
+        tier: app
+    spec:
+      runtime:
+        resources:
+          instanceType: datumcloud/d1-standard-2
+        virtualMachine:
+          volumeAttachments:
+          - name: boot
+          - name: secret
+            mountPath: /secret
+          - name: configmap
+            mountPath: /configmap
+      networkInterfaces:
+      - network:
+          name: default
+        networkPolicy:
+          ingress:
+            - ports:
+              - port: 22
+              from:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+      volumes:
+      - name: boot
+        disk:
+          template:
+            spec:
+              type: pd-standard
+              populator:
+                image:
+                  name: datumcloud/ubuntu-2204-lts
+      - name: secret
+        secret:
+          secretName: workload-vm-sample-secret
+      - name: configmap
+        configMap:
+          name: workload-vm-sample-configmap
+  placements:
+  - name: us-south
+    cityCodes:
+    - DFW
+    scaleSettings:
+      minReplicas: 1
+```
+
+{{% /tab %}}
+{{< /tabpane >}}
 
 ## Workload Deployments
 

--- a/content/en/docs/api/workloads.md
+++ b/content/en/docs/api/workloads.md
@@ -99,3 +99,8 @@ placements:
     scaleSettings:
       minReplicas: 1
 ```
+
+### Detailed API Specification
+
+For a complete API specification of the Location resource, refer to the
+[Detailed Reference](https://github.com/datum-cloud/workload-operator/blob/main/docs/api/workloads.md).

--- a/content/en/docs/api/workloads.md
+++ b/content/en/docs/api/workloads.md
@@ -1,0 +1,101 @@
+---
+title: Workloads
+description: Datum lets you deploy and manage workloads. Today, these workloads can be either virtual machines or containers. They're defined like any other Kubernetes custom resource, usually in YAML.
+---
+
+### Workloads Overview
+
+Datum lets you deploy and manage workloads. Today, these workloads can be either virtual machines or containers. They're defined like any other Kubernetes custom resource, usually in YAML.
+
+### Example Container Workload
+
+This is an example of a workload that runs an nginx container and places it first location you have defined in your Datum project that is associated with `DFW` (Dallas Fort Worth).
+
+```yaml
+apiVersion: compute.datumapis.com/v1alpha
+kind: Workload
+metadata:
+  name: nginx-workload
+spec:
+  template:
+    spec:
+      runtime:
+        resources:
+          instanceType: datumcloud/d1-standard-2
+        sandbox:
+          containers:
+            - name: nginx
+              image: nginx:latest
+              ports:
+                - name: http
+                  port: 8080
+      networkInterfaces:
+        - network:
+            name: default
+          networkPolicy:
+            ingress:
+              - ports:
+                - port: 8080
+                from:
+                  - ipBlock:
+                      cidr: 0.0.0.0/0
+  placements:
+    - name: us
+      cityCodes: ['DFW']
+      scaleSettings:
+        minReplicas: 1
+```
+
+### Workload Components
+
+Let's walk through the sample spec and review each of the key components.
+
+* The name of the workload.
+
+  ```yaml
+  name: nginx-workload
+  ```
+
+* The runtime environment for the workload. Datum currently supports Virtual Machines or containers as runtime environments, our sample uses a container runtime.
+
+  ```yaml
+  runtime:
+    sandbox:
+      containers:
+        - name: nginx
+          image: nginx/nginx
+          ports:
+            - name: http
+              port: 8080
+  ```
+
+* The type of instance to use for the workload, currently `datumcloud/d1-standard-2` is the only supported type.
+
+  ```yaml
+  instanceType: datumcloud/d1-standard-2
+  ```
+
+* The network to connect the workload to, which ports should to expose, and what IPs to allow access from.
+
+  ```yaml
+  networkInterfaces:
+  - network:
+      name: default
+    networkPolicy:
+      ingress:
+        - ports:
+          - port: 8080
+          from:
+            - ipBlock:
+                cidr: 0.0.0.0/0
+  ```
+
+* The placement of the workload, which defines where the workload should run. In this case, it will run in the first location in your project associated with `DFW` (Dallas Fort Worth).
+
+```yaml  
+placements:
+  - name: us
+    cityCodes: ['DFW']
+    scaleSettings:
+      minReplicas: 1
+```


### PR DESCRIPTION
This is a PR with changes to add a new Resources page to the Datum documentation site. The idea is a quick glossary style page of all the various custom resources Datum has and some sample yaml of each resource. I've added a number of samples, but these could always be improved and more added. 

Additionally, I added a few deeper dive pages for Locations, Networks, and Workloads. I'd suggest perhaps organizing these somehow, like under a "Deploying Workloads" section where you have details on all the resources critical for workload deployment.

One potential future improvement could include adding some detailed examples of setting up Gateways and HTTPRoutes.