### PR TITLE
Rewrite the Gateway tutorial to direct users to use HTTPProxies.

### DIFF
--- a/content/en/docs/tutorials/gateway/_index.md
+++ b/content/en/docs/tutorials/gateway/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Create a Datum Gateway (Reverse Proxy)
+title: Create a Datum HTTPProxy (Reverse Proxy)
 weight: 1
 ---
 
@@ -11,176 +11,378 @@ This tutorial assumes you have already:
 - [Installed and configured the necessary tools]({{< ref "tools.md" >}})
 - [Created a Datum project]({{< ref "create-project" >}})
 
-## Understanding Datum Gateways
+## Understanding HTTPProxy
 
-A Datum Gateway acts as a reverse proxy that manages incoming traffic to your services. It's built on top of the Kubernetes Gateway API specification and provides a way to:
+An HTTPProxy is a simplified way to configure HTTP reverse proxy functionality
+in Datum. It automatically creates and manages Gateway, HTTPRoute, and
+EndpointSlice resources for you, reducing the complexity of manual
+configuration.
 
-- Route traffic to different services based on hostnames and paths
-- Load balance requests across multiple backend services
-- Apply TLS termination
-- Monitor traffic flow
+HTTPProxy provides:
 
-This tutorial will create a Datum Gateway that will use
-[example.com](https://www.example.com) as the origin service.
+- Simple single-manifest configuration for reverse proxy setups
+- Automatic backend endpoint resolution from URLs
+- Built-in support for path-based routing and header manipulation
+- Seamless integration with Datum's global proxy infrastructure
 
-## Creating a Basic Gateway
+This tutorial will create an HTTPProxy that proxies traffic to
+[example.com](https://www.example.com) as the backend service.
 
-Let's start by creating a simple Gateway that will listen for HTTP traffic on port 80. Here's a basic Gateway configuration:
+## Creating a Basic HTTPProxy
 
-```yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: my-gateway
-spec:
-  gatewayClassName: datum-external-global-proxy
-  listeners:
-    - name: http
-      protocol: HTTP
-      port: 80
-      allowedRoutes:
-        namespaces:
-          from: Same
-```
+Let's create a simple HTTPProxy that will route traffic to example.com. Here's
+the basic configuration:
 
-Apply this configuration using kubectl:
+{{< tabpane text=true left=true >}}
+  {{% tab header="Apply from stdin" lang="en" %}}
+
+  ```yaml
+  cat <<EOF | kubectl apply -f -
+  apiVersion: networking.datumapis.com/v1alpha
+  kind: HTTPProxy
+  metadata:
+    name: httpproxy-sample-example-com
+  spec:
+    rules:
+        - backends:
+          - endpoint: https://example.com
+  EOF
+  ```
+
+  {{% /tab %}}
+
+  {{% tab header="Apply from file" lang="en" %}}
+
+  Save and apply the following resource to your project:
+
+  ```yaml
+  apiVersion: networking.datumapis.com/v1alpha
+  kind: HTTPProxy
+  metadata:
+    name: httpproxy-sample-example-com
+  spec:
+    rules:
+        - backends:
+          - endpoint: https://example.com
+  ```
+
+  {{% /tab %}}
+{{< /tabpane >}}
+
+Summary of this HTTPProxy's configuration:
+
+- **Rule Matching**: A default path prefix match is inserted which matches all
+  incoming requests and forwards them to the backend.
+
+- **Backend URL Components**: The `endpoint: https://example.com` URL is parsed
+  to extract:
+  - **Scheme**: `https` (determines the protocol for backend connections)
+  - **Host**: `example.com` (the target hostname for proxy requests)
+  - **Port**: `443` (inferred from HTTPS scheme)
+
+- **Single Backend Limitation**: Currently, HTTPProxy supports only one backend
+  endpoint per rule.
+
+## Verifying the HTTPProxy
+
+Check that your HTTPProxy was created and programmed successfully:
 
 ```shell
-kubectl apply -f gateway.yaml
+kubectl get httpproxy httpproxy-sample-example-com
 ```
 
-Verify the Gateway was created:
+You should see output similar to:
+
+```shell
+NAME                           HOSTNAME                                                       PROGRAMMED   AGE
+httpproxy-sample-example-com   c4b9c93d-97c2-46d1-972e-48197cc9a9da.prism.e2e.env.datum.net   True         11s
+```
+
+The key fields in this output are:
+
+- **NAME**: Your HTTPProxy resource name
+- **HOSTNAME**: The auto-generated hostname where your proxy is accessible
+- **PROGRAMMED**: `True` indicates the HTTPProxy has been successfully
+  configured
+- **AGE**: How long the resource has existed
+
+## Testing the HTTPProxy
+
+Once your HTTPProxy shows `PROGRAMMED: True`, you can test it using the
+generated hostname:
+
+```shell
+# Use the hostname from kubectl get httpproxy output
+curl -v http://c4b9c93d-97c2-46d1-972e-48197cc9a9da.prism.e2e.env.datum.net
+```
+
+Alternatively, copy the hostname into a browser to view example.com content
+served through your Datum HTTPProxy.
+
+## Understanding Generated Resources
+
+HTTPProxy automatically creates several Kubernetes resources behind the scenes:
+
+### 1. Gateway Resource
+
+Check the generated Gateway:
 
 ```shell
 kubectl get gateway
 ```
 
-## Configuring Endpoints
+The HTTPProxy creates a Gateway that handles incoming traffic and provides the
+external hostname.
 
-Endpoints in Datum Gateway are defined using EndpointSlice resources, which provide a more efficient way to manage service endpoints. Here's an example of how to define endpoints for your gateway:
+### 2. HTTPRoute Resource
 
-```yaml
-apiVersion: discovery.k8s.io/v1
-kind: EndpointSlice
-metadata:
-  name: my-endpoint
-addressType: IPv4
-endpoints:
-- addresses:
-  - 23.192.228.80
-  conditions:
-    ready: true
-    serving: true
-- addresses:
-  - 23.192.228.84
-  conditions:
-    ready: true
-    serving: true
-ports:
-- name: https
-  appProtocol: https
-  port: 443
-```
-
-This EndpointSlice configuration:
-- Defines a set of endpoints for a service named "my-endpoint"
-- Specifies the endpoint by 2x IPv4 addresses
-- Includes port configuration for HTTP traffic
-- Includes readiness conditions for the  endpoint
-
-Apply the endpoints:
+View the generated HTTPRoute:
 
 ```shell
-kubectl apply -f endpoints.yaml
-```
-
-## Creating Routes
-
-Routes define how traffic should be directed to your services. Let's create a simple HTTPRoute that directs traffic to a backend service:
-
-```yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: my-route
-spec:
-  parentRefs:
-    - name: my-gateway
-      kind: Gateway
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
-      backendRefs:
-        - group: discovery.k8s.io
-          kind: EndpointSlice
-          name: my-endpoint
-          port: 443
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            hostname: "example.com"
-```
-
-This route configuration:
-- Attaches to our previously created gateway
-- Routes all requests with path prefix "/"  with a hostname rewrite to "example.com".
-
-Apply the route:
-
-```shell
-kubectl apply -f route.yaml
-```
-
-## Verifying the Setup
-
-Check the status of your gateway components:
-
-```shell
-# Check Gateway status
-kubectl get gateway -o wide
-```
-
-Note: This output will provide the address to be used with cURL, below.
-
-# Check EndpointSlices
-```shell
-# Check Endpoint status
-kubectl get endpointslices
-```
-
-# Check Routes
-```shell
-# Check Route status
 kubectl get httproute
 ```
 
-# Check the Service using cURL
+The HTTPRoute defines the routing rules and connects the Gateway to the backend
+endpoints.
+
+### 3. EndpointSlice Resource
+
+Examine the generated EndpointSlice:
 
 ```shell
-# Use cURL to test the gateway
-curl -sv http://$ADDRESS (ending in `datum-dns.net from above step`)
+kubectl get endpointslices
 ```
 
-Alternatively, copy/paste $ADDRESS into a browser to view example.com via a
-Datum gateway.
+The EndpointSlice contains the resolved IP addresses and port information for
+the backend service extracted from your `endpoint` URL.
+
+## Advanced Configuration
+
+HTTPProxy leverages many existing [Gateway API][gateway-api] features, including
+[matches][gateway-matches] and [filters][gateway-filters]. Datum supports all
+[Core][gateway-core] Gateway API capabilities, providing you with a rich set of
+traffic management features through the simplified HTTPProxy interface.
+
+[gateway-api]: https://gateway-api.sigs.k8s.io/
+[gateway-matches]: https://gateway-api.sigs.k8s.io/reference/spec/#httproutematch
+[gateway-filters]: https://gateway-api.sigs.k8s.io/reference/spec/#httproutefilter
+[gateway-core]: https://gateway-api.sigs.k8s.io/concepts/conformance/?h=core#2-support-levels
+
+### Multiple Path Rules
+
+You can define multiple routing rules within a single HTTPProxy:
+
+{{< tabpane text=true left=true >}}
+  {{% tab header="Apply from stdin" lang="en" %}}
+
+  ```yaml
+  cat <<EOF | kubectl apply -f -
+  apiVersion: networking.datumapis.com/v1alpha
+  kind: HTTPProxy
+  metadata:
+    name: httpproxy-multi-path
+  spec:
+    rules:
+      - name: root-route
+        matches:
+          - path:
+              type: PathPrefix
+              value: /
+        backends:
+          - endpoint: https://example.com
+      - name: headers-route
+        matches:
+          - path:
+              type: PathPrefix
+              value: /headers
+        backends:
+          - endpoint: https://httpbingo.org
+  EOF
+  ```
+
+  {{% /tab %}}
+
+  {{% tab header="Apply from file" lang="en" %}}
+
+  Save and apply the following resource to your project:
+
+  ```yaml
+  apiVersion: networking.datumapis.com/v1alpha
+  kind: HTTPProxy
+  metadata:
+    name: httpproxy-multi-path
+  spec:
+    rules:
+      - name: root-route
+        matches:
+          - path:
+              type: PathPrefix
+              value: /
+        backends:
+          - endpoint: https://example.com
+      - name: headers-route
+        matches:
+          - path:
+              type: PathPrefix
+              value: /headers
+        backends:
+          - endpoint: https://httpbingo.org
+  ```
+
+  {{% /tab %}}
+{{< /tabpane >}}
+
+### Header-based Routing and rewrite filters
+
+HTTPProxy supports header-based matching and request rewrites:
+
+{{< tabpane text=true left=true >}}
+  {{% tab header="Apply from stdin" lang="en" %}}
+
+  ```yaml
+  cat <<EOF | kubectl apply -f -
+  apiVersion: networking.datumapis.com/v1alpha
+  kind: HTTPProxy
+  metadata:
+    name: httpproxy-header-based
+  spec:
+    rules:
+      - name: headers
+        matches:
+          - headers:
+              - name: x-rule
+                value: headers
+        filters:
+          - type: URLRewrite
+            urlRewrite:
+              path:
+                type: ReplaceFullPath
+                replaceFullPath: /headers
+        backends:
+          - endpoint: https://httpbingo.org
+      - name: ip
+        matches:
+          - headers:
+              - name: x-rule
+                value: ip
+        filters:
+          - type: URLRewrite
+            urlRewrite:
+              path:
+                type: ReplaceFullPath
+                replaceFullPath: /ip
+        backends:
+          - endpoint: https://httpbingo.org
+  EOF
+  ```
+
+  {{% /tab %}}
+
+  {{% tab header="Apply from file" lang="en" %}}
+
+  Save and apply the following resource to your project:
+
+  ```yaml
+  apiVersion: networking.datumapis.com/v1alpha
+  kind: HTTPProxy
+  metadata:
+    name: httpproxy-header-based
+  spec:
+    rules:
+      - name: headers
+        matches:
+          - headers:
+              - name: x-rule
+                value: headers
+        filters:
+          - type: URLRewrite
+            urlRewrite:
+              path:
+                type: ReplaceFullPath
+                replaceFullPath: /headers
+        backends:
+          - endpoint: https://httpbingo.org
+      - name: ip
+        matches:
+          - headers:
+              - name: x-rule
+                value: ip
+        filters:
+          - type: URLRewrite
+            urlRewrite:
+              path:
+                type: ReplaceFullPath
+                replaceFullPath: /ip
+        backends:
+          - endpoint: https://httpbingo.org
+  ```
+
+  {{% /tab %}}
+{{< /tabpane >}}
+
+Once your HTTPProxy shows `PROGRAMMED: True`, you can test it using the
+generated hostname:
+
+**Headers Rule**:
+
+```shell
+# Use the hostname from kubectl get httpproxy output
+curl -H "x-rule: headers" -v http://c4b9c93d-97c2-46d1-972e-48197cc9a9da.prism.e2e.env.datum.net
+```
+
+You should see output similar to:
+
+```json
+{
+  "headers": {
+    "Accept": [
+      "*/*"
+    ],
+    // ...
+  }
+}
+```
+
+**IP Rule**:
+
+```shell
+# Use the hostname from kubectl get httpproxy output
+curl -H "x-rule: ip" -v http://c4b9c93d-97c2-46d1-972e-48197cc9a9da.prism.e2e.env.datum.net
+```
+
+You should see output similar to:
+
+```json
+{
+  "origin": "127.0.0.1"
+}
+```
 
 ## Next Steps
 
-- Understand how to use Datum's observability tools via Telemetry Exporters.
+- Coming soon! Learn about Datum's observability tools and telemetry exporters
 
 ## Troubleshooting
 
 Common issues and their solutions:
 
-1. Gateway not accepting traffic:
-   - Verify the Gateway is in the "Ready" state
-   - Check that the gatewayClassName is properly configured to be `datum-external-global-proxy`.
-   - Ensure the listeners are correctly defined
+1. **HTTPProxy not showing PROGRAMMED: True**:
+   - Check the HTTPProxy status: `kubectl describe httpproxy <name>`
+   - Verify the backend endpoint URL is accessible
+   - Ensure the Datum network services operator is running
 
-2. Endpoints not receiving traffic:
-   - Ensure the EndpointSlice addresses are correct
-   - Verify the ports are correctly configured
-   - Check that the endpoints are marked as ready
+2. **Generated hostname not responding**:
+   - Verify the HTTPProxy status shows `PROGRAMMED: True`
+   - Check that the backend service at the endpoint URL is accessible
+   - Review the generated Gateway status: `kubectl get gateway -o wide`
 
+3. **Backend URL parsing issues**:
+   - Ensure the endpoint URL includes the scheme (http:// or https://)
+   - Verify the hostname in the URL is resolvable
+   - Check for any typos in the endpoint URL
+
+4. **Checking generated resources**:
+   - List all related resources: `kubectl get gateway,httproute,endpointslices`
+   - Use `kubectl describe` on any resource showing issues
+   - Review logs from the network services operator if resources aren't being
+     created


### PR DESCRIPTION
## Summary

Part of https://github.com/datum-cloud/enhancements/issues/200

Fixes https://github.com/datum-cloud/docs/issues/47

The "Apply from stdin" / "Apply from file" tab idea was taken from https://gateway.envoyproxy.io/docs/tasks/traffic/http-redirect/

## Future work

- Follow up with instructions on setting up a Grafana account and an export policy to send telemetry via prometheus remote write.
- Add API reference documentation similar to what's seen at https://github.com/datum-cloud/network-services-operator/blob/integration/httpproxy/docs/api/httpproxies.md, but formatted in a more user friendly way.