### PR TITLE
Update project creation tutorial to point users to set up an HTTP proxy instead of compute as a next step.

### DIFF
--- a/content/en/docs/tasks/create-project/_index.md
+++ b/content/en/docs/tasks/create-project/_index.md
@@ -111,4 +111,4 @@ DESCRIPTION:
 
 ## What's next
 
-- [Set up a Datum managed Location backed by GCP]({{< relref "infra-provider-gcp">}})
+- [Create a Datum HTTP Proxy]({{< relref "httpproxy">}})


### PR DESCRIPTION
The GCP tutorial is actually hidden from navigation today. The intent is to have users explore HTTP proxies until we focus on polishing compute.