### PR TITLE
bugfix: fix core milo api groups in resources

### DIFF
--- a/content/en/docs/api/connecting-to-the-api.md
+++ b/content/en/docs/api/connecting-to-the-api.md
@@ -33,7 +33,7 @@ Most users will interact with a project control plane to manage resources.
 The following base URL can be used to access an organization's control plane:
 
 ```url
-https://api.datum.net/apis/resourcemanager.datumapis.com/v1alpha/organizations/{organization_id}/control-plane
+https://api.datum.net/apis/resourcemanager.miloapis.com/v1alpha1/organizations/{organization_id}/control-plane
 ```
 
 ### Project Control Plane
@@ -43,7 +43,7 @@ plane created to manage resources. Use the following base URL to access a
 project's control plane:
 
 ```url
-https://api.datum.net/apis/resourcemanager.datumapis.com/v1alpha/projects/{project_id}/control-plane
+https://api.datum.net/apis/resourcemanager.miloapis.com/v1alpha1/projects/{project_id}/control-plane
 ```
 
 ## API Discovery
@@ -54,13 +54,13 @@ example that demonstrates some services available in an organization's control
 plane.
 
 ```shell
-$ curl -sS 'https://api.datum.net/apis/resourcemanager.datumapis.com/v1alpha/organizations/{organization_id}/control-plane/openapi/v3' \
+$ curl -sS 'https://api.datum.net/apis/resourcemanager.miloapis.com/v1alpha1/organizations/{organization_id}/control-plane/openapi/v3' \
    -H "Authorization: Bearer $(datumctl auth get-token)"
 
 {
   "paths": {
-    "apis/resourcemanager.datumapis.com/v1alpha": {
-      "serverRelativeURL": "/openapi/v3/apis/resourcemanager.datumapis.com/v1alpha?hash=D0A1DF465E973D5C8FC30D065B864272955A66C14609154E7EAECC0426C71E99F3982ECBA4D5C6C92EC3DF497E159F2129D0F8A20CDC8E5746583D1BFEA80A52"
+    "apis/resourcemanager.miloapis.com/v1alpha1": {
+      "serverRelativeURL": "/openapi/v3/apis/resourcemanager.miloapis.com/v1alpha1?hash=D0A1DF465E973D5C8FC30D065B864272955A66C14609154E7EAECC0426C71E99F3982ECBA4D5C6C92EC3DF497E159F2129D0F8A20CDC8E5746583D1BFEA80A52"
     },
   ]
 }

--- a/content/en/docs/api/resources.md
+++ b/content/en/docs/api/resources.md
@@ -17,7 +17,7 @@ resources and how to use them.
 ```yaml
 apiVersion: v1
 items:
-- apiVersion: telemetry.datumapis.com/v1alpha1
+- apiVersion: telemetry.miloapis.com/v1alpha1
   kind: ExportPolicy
   metadata:
     name: exportpolicy
@@ -43,7 +43,7 @@ items:
     sources:
     - metrics:
         metricsql: |
-          {service_name="telemetry.datumapis.com"}
+          {service_name="telemetry.miloapis.com"}
       name: telemetry-metrics
     - metrics:
         metricsql: |
@@ -57,7 +57,7 @@ metadata: {}
 {{% tab header="Detailed Example With Comments" text=true %}}
 
 ```yaml
-apiVersion: telemetry.datumapis.com/v1alpha1
+apiVersion: telemetry.miloapis.com/v1alpha1
 kind: ExportPolicy
 metadata:
   name: exportpolicy-sample
@@ -78,7 +78,7 @@ spec:
         # familiar with using metricsql queries to select metric data from
         # Victoria Metrics.
         metricsql: |
-          {service_name="telemetry.datumapis.com"}
+          {service_name="telemetry.miloapis.com"}
   sinks:
     - name: grafana-cloud-metrics
       sources:

--- a/content/en/docs/api/resources.md
+++ b/content/en/docs/api/resources.md
@@ -190,11 +190,11 @@ spec:
 
 ## Projects
 
-[Detailed Projects API Reference](https://github.com/datum-cloud/datum/blob/milo-apiserver/docs/api/resourcemanager.datumapis.com_projects.yaml.md)
+[Detailed Projects API Reference](https://github.com/datum-cloud/milo/blob/main/docs/api/resourcemanager.md)
 {{< tabpane>}}
 {{% tab header="Sample Project" text=true %}}
 
-```apiVersion: resourcemanager.datumapis.com/v1alpha
+```apiVersion: resourcemanager.miloapis.com/v1alpha1
 kind: Project
 metadata:
   generateName: sample-project-

--- a/content/en/docs/tasks/create-project/_index.md
+++ b/content/en/docs/tasks/create-project/_index.md
@@ -38,7 +38,7 @@ Note that `generateName` is used here, which will result in a name with the pref
 `intro-project-` and a random suffix.
 
 ```yaml
-apiVersion: resourcemanager.datumapis.com/v1alpha
+apiVersion: resourcemanager.miloapis.com/v1alpha1
 kind: Project
 metadata:
   generateName: intro-project-
@@ -54,7 +54,7 @@ kubectl create -f intro-project.yaml
 The output is similar to:
 
 ```shell
-project.resourcemanager.datumapis.com/intro-project-zj6wx created
+project.resourcemanager.miloapis.com/intro-project-zj6wx created
 ```
 
 Copy the generated project name, in this example it is `intro-project-zj6wx`.


### PR DESCRIPTION
When we introduced Milo as the core foundation for Datum Cloud, we adjusted some of the services to be part of Milo's API group instead of Datum's. This reflects those changes in the documentation.