### PR TITLE
fix: rename Machine Accounts → Service Accounts in docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -70,7 +70,7 @@
             "group": "Platform",
             "pages": [
               "platform/setup",
-              "platform/machine-accounts",
+              "platform/service-accounts",
               "platform/metrics-export",
               "platform/activity-logs",
               "platform/secrets",

--- a/platform/service-accounts.mdx
+++ b/platform/service-accounts.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Machine Accounts"
+title: "Service Accounts"
 description: "Create non-human identities for applications, CI/CD pipelines, and services to authenticate with Datum APIs"
 ---
 
-Machine accounts give non-human workloads — CI/CD pipelines, backend services, and scripts — a stable cryptographic identity to call Datum APIs. They authenticate using RSA key pairs rather than shared passwords or long-lived user tokens.
+Service accounts give non-human workloads — CI/CD pipelines, backend services, and scripts — a stable cryptographic identity to call Datum APIs. They authenticate using RSA key pairs rather than shared passwords or long-lived user tokens.
 
-## When to use machine accounts
+## When to use service accounts
 
 | Use case | Example |
 | --- | --- |
@@ -14,14 +14,14 @@ Machine accounts give non-human workloads — CI/CD pipelines, backend services,
 | Backend services | A service authenticating as itself, not as a user |
 | Local automation | Scripts that run without a browser-based login |
 
-## Create a machine account
+## Create a service account
 
 1. Open your project in the [Datum Cloud portal](https://cloud.datum.net).
-2. Navigate to **Machine Accounts** in the left sidebar.
-3. Click **Create machine account**.
+2. Navigate to **Service Accounts** in the left sidebar.
+3. Click **Create service account**.
 4. Enter a lowercase name (e.g. `ci-deploy`) and an optional display name.
    <Frame>
-     ![Machine account creation form](/images/image.png)
+     ![Service account creation form](/images/image.png)
    </Frame>
 5. Select a key type:
    - **Datum-managed** — Datum generates an RSA key pair. The private key is shown **once** at creation time. Download it as a JSON credentials file before closing the wizard.
@@ -31,7 +31,7 @@ Machine accounts give non-human workloads — CI/CD pipelines, backend services,
      </Frame>
 6. Click **Create**. Once the account's identity email is provisioned, your credentials are ready.
    <Frame>
-     ![Machine account created, credentials available to download](/images/image-2.png)
+     ![Service account created, credentials available to download](/images/image-2.png)
    </Frame>
 
 <Note>
@@ -40,7 +40,7 @@ Machine accounts give non-human workloads — CI/CD pipelines, backend services,
 
 ## Manage keys
 
-Open a machine account and navigate to the **Keys** tab to add or revoke keys.
+Open a service account and navigate to the **Keys** tab to add or revoke keys.
 
 - **Add a key** — create an additional datum-managed or user-managed key at any time.
 - **Revoke a key** — immediately invalidates the key. Any tokens issued with it will stop working at expiry.
@@ -49,7 +49,7 @@ To rotate keys with zero downtime: add the new key, update your workloads to use
 
 ## Assign roles
 
-Machine accounts are IAM principals like any other member. Assign roles from the **Policy Bindings** tab on the account's detail page, or from **Settings → Members** in your project or organization.
+Service accounts are IAM principals like any other member. Assign roles from the **Roles** tab on the account's detail page, or from **Settings → Members** in your project or organization.
 
 <Frame>
   ![Policy Bindings form showing role assignments](/images/image-3.png)
@@ -62,7 +62,7 @@ Machine accounts are IAM principals like any other member. Assign roles from the
 
 ## Using credentials
 
-After creating a machine account, you'll have a credentials file to use for authentication.
+After creating a service account, you'll have a credentials file to use for authentication.
 
 ### Credentials file format
 
@@ -70,7 +70,7 @@ When you create a datum-managed key, Datum returns a JSON credentials file:
 
 ```json
 {
-  "type": "datum_machine_account",
+  "type": "datum_service_account",
   "client_id": "...",
   "private_key_id": "...",
   "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...",


### PR DESCRIPTION
## Summary

Updates docs to match the milo v0.24.7+ rename of `MachineAccount` → `ServiceAccount`.

- Renames `platform/machine-accounts.mdx` → `platform/service-accounts.mdx`
- Updates all terminology throughout: "machine account" → "service account"
- Updates credentials file `type` field from `datum_machine_account` → `datum_service_account`
- Updates sidebar nav entry in `docs.json`
- Corrects the Roles tab name from "Policy Bindings" to "Roles"

## Test plan

- [ ] Docs site builds without broken links
- [ ] `/platform/service-accounts` renders correctly
- [ ] Nav sidebar shows "Service Accounts" entry