### PR TITLE
fix(ai): remove duplicate "Open in Claude" contextual button

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -187,7 +187,6 @@
   },
   "contextual": {
     "options": [
-      "claude",
       "chatgpt",
       "copy",
       "view"


### PR DESCRIPTION
## Summary

- Removes `"claude"` from `contextual.options` in `docs.json`
- The `ai.type: chat` floating widget already provides the "Open in Claude" experience — having both caused Mintlify to render the button twice per page
- AI crawlers saw `AnthropicOpen in Claude` duplicated mid-content, splitting paragraphs and degrading coherence

Closes #13

## Test plan

- [ ] Deploy preview and visit any docs page (e.g. `/ai-edge/overview`)
- [ ] Confirm "Open in Claude" appears only once (floating widget, not inline)
- [ ] Crawl the page markdown and verify `AnthropicOpen in Claude` appears only once