### PR TITLE
feat: add Agents section with Skills pages

### DIFF
--- a/agents/llms-txt.mdx
+++ b/agents/llms-txt.mdx
@@ -1,0 +1,43 @@
+---
+title: "llms.txt"
+description: "A single-file index agents can fetch to discover Datum's full documentation surface."
+---
+
+`llms.txt` is a small, machine-readable file at the root of the docs site that lists every page agents should know about. It's the lowest-friction way for an agent to bootstrap context about Datum without crawling — a single fetch, a complete map.
+
+## Where it lives
+
+The canonical URL: **[https://datum.net/docs/llms.txt](https://datum.net/docs/llms.txt)**
+
+It's regenerated automatically on every docs deploy, so the index always matches the live site.
+
+## Using it from an agent
+
+Most modern agents will fetch this automatically when given a Datum-related task. To prompt explicitly:
+
+```
+Fetch https://datum.net/docs/llms.txt before answering.
+Use it to discover relevant pages.
+```
+
+## What's in it
+
+The file is organized into two sections:
+
+- **Docs** — the full set of documentation pages, including:
+  - AI Edge (WAF, HTTPProxy, traffic protection)
+  - CLI commands (`datumctl` reference pages)
+  - Connectors / Tunnels
+  - Datum MCP
+  - `datumctl` guides (authentication, activity, overview)
+  - Desktop Apps
+  - DNS and Domains
+  - Galactic VPC
+  - Platform (account setup, service accounts, metrics export, secrets, locations, activity logs)
+  - Overview, Features, Kubernetes, Get Involved
+- **Optional** — community links (Discord, YouTube, GitHub)
+
+## Related
+
+- [Skills](/agents/skills) — pre-packaged procedural knowledge agents load on demand
+- [Datum MCP](/datum-mcp) — live API access via Model Context Protocol

--- a/agents/overview.mdx
+++ b/agents/overview.mdx
@@ -1,0 +1,34 @@
+---
+title: "Agents Overview"
+description: "How AI agents work with Datum Cloud — Skills, MCP, llms.txt, and datumctl."
+---
+
+Datum is built for agents as first-class users. Rather than wrapping an API in a chat interface, Datum exposes the same primitives humans use — YAML manifests, `datumctl` commands, and CRD-based resources — in ways that agents can reason about reliably. This section covers the four surfaces agents use to work with Datum: **Skills** (procedural know-how), **Datum MCP** (live API access), **llms.txt** (doc index), and **datumctl** (the CLI agents drive directly).
+
+## The four agent surfaces
+
+<CardGroup cols={2}>
+  <Card title="Skills" icon="book-open" href="/agents/skills">
+    Self-contained instructions agents load on demand. One skill per Datum resource — install once, agents handle the rest.
+  </Card>
+  <Card title="Datum MCP" icon="plug" href="/datum-mcp">
+    The official Model Context Protocol server. Gives agents authenticated, live access to Datum APIs.
+  </Card>
+  <Card title="llms.txt" icon="file-lines" href="/agents/llms-txt">
+    A single index file at datum.net/docs/llms.txt that agents fetch to discover the full documentation surface.
+  </Card>
+  <Card title="datumctl" icon="terminal" href="/datumctl/overview">
+    The CLI. Agents invoke it directly for any platform action — same surface humans use.
+  </Card>
+</CardGroup>
+
+## Which one should I use?
+
+| If your agent needs to… | Use |
+|---|---|
+| Know *how* to do a Datum task (e.g. attach a domain to an HTTPProxy) | **Skills** |
+| Read or write live Datum resources during a task | **Datum MCP** |
+| Discover what documentation exists | **llms.txt** |
+| Execute commands directly | **datumctl** |
+
+These surfaces layer together. A typical agent session loads one or two relevant Skills at startup, calls `datumctl` or Datum MCP to act, and falls back to `llms.txt` when it needs deeper context. See [Skills](/agents/skills) to get started.

--- a/agents/skills/ai-edge.mdx
+++ b/agents/skills/ai-edge.mdx
@@ -1,0 +1,68 @@
+---
+title: "AI Edge skill"
+description: "Teach agents to manage WAF, auth, and traffic policies on Datum's AI Edge — attaching policies to Gateways and HTTPRoutes via datumctl."
+---
+
+The AI Edge skill helps agents manage traffic protection and security policies in Datum Cloud. It covers the three policy types that attach to [AI Edge](/ai-edge/overview) resources via `targetRefs`: `TrafficProtectionPolicy` (WAF), `SecurityPolicy` (auth/authz), and `BackendTrafficPolicy` (rate limiting, circuit breakers, compression).
+
+## Install
+
+<CodeGroup>
+
+```bash Claude Code
+/plugin marketplace add datum-cloud/skills
+/plugin install datum-cloud@datum-cloud
+```
+
+```bash npx skills
+npx skills add https://github.com/datum-cloud/skills
+```
+
+```bash Cursor
+# Settings → Rules → Add Rule → Remote Rule (GitHub)
+# Repository: datum-cloud/skills
+```
+
+</CodeGroup>
+
+<Note>
+Once installed, the skill activates automatically when you ask an agent to work with AI Edge on Datum. No further configuration needed.
+</Note>
+
+## Capabilities
+
+- Deploy a Web Application Firewall (TrafficProtectionPolicy) with OWASP Core Rule Set enforcement
+- Configure WAF detection (`Observe`) and blocking (`Enforce`) modes
+- Attach authentication and authorization policies (SecurityPolicy) to gateways and routes
+- Manage circuit breakers, compression, rate limiting, and fault injection (BackendTrafficPolicy)
+- List, inspect, and update policies across a project
+- Preview changes before applying with `datumctl diff`
+- Delete policies safely
+- Check permissions before acting
+
+## How it relates to other Datum surfaces
+
+- **Product docs:** [AI Edge](/ai-edge/overview) — the human-facing reference for WAF and traffic policies
+- **Datum MCP:** [Datum MCP](/datum-mcp) — for agents that need to act on Gateways and HTTPRoutes during a session
+- **`datumctl`:** [datumctl overview](/datumctl/overview) — `get`, `describe`, `apply`, `diff`, `delete` commands the skill teaches agents to use
+
+## View the full skill
+
+The canonical SKILL.md lives in the [datum-cloud/skills](https://github.com/datum-cloud/skills) repo:
+
+<CardGroup cols={2}>
+  <Card
+    title="On GitHub"
+    icon="github"
+    href="https://github.com/datum-cloud/skills/blob/main/skills/ai-edge/SKILL.md"
+  >
+    Browse the skill source, including frontmatter and full instructions.
+  </Card>
+  <Card
+    title="Raw SKILL.md"
+    icon="file-code"
+    href="https://raw.githubusercontent.com/datum-cloud/skills/main/skills/ai-edge/SKILL.md"
+  >
+    Direct URL for agents that fetch skills by URL.
+  </Card>
+</CardGroup>

--- a/agents/skills/client-traffic.mdx
+++ b/agents/skills/client-traffic.mdx
@@ -1,0 +1,71 @@
+---
+title: "Client Traffic skill"
+description: "Teach agents to configure TLS termination, HTTP/3, connection limits, and client IP detection on Datum Cloud gateways."
+---
+
+The Client Traffic skill helps agents manage how Datum Cloud edge gateways accept and handle incoming client connections. It covers [AI Edge](/ai-edge/overview) gateway-level settings — TLS termination, mutual TLS (mTLS), HTTP/2 and HTTP/3 (QUIC), connection timeouts and limits, and real client IP detection — all configured by attaching a `ClientTrafficPolicy` to a Gateway listener.
+
+## Install
+
+<CodeGroup>
+
+```bash Claude Code
+/plugin marketplace add datum-cloud/skills
+/plugin install datum-cloud@datum-cloud
+```
+
+```bash npx skills
+npx skills add https://github.com/datum-cloud/skills
+```
+
+```bash Cursor
+# Settings → Rules → Add Rule → Remote Rule (GitHub)
+# Repository: datum-cloud/skills
+```
+
+</CodeGroup>
+
+<Note>
+Once installed, the skill activates automatically when you ask an agent to configure client traffic settings on Datum. No further configuration needed.
+</Note>
+
+## Capabilities
+
+- Configure TLS termination: minimum/maximum TLS version, cipher suites, ALPN protocols
+- Require and validate client certificates (mutual TLS / mTLS)
+- Enable HTTP/2 and HTTP/3 (QUIC) on gateway listeners
+- Set client-facing connection timeouts and idle timeouts
+- Enforce maximum concurrent connections and per-connection request limits
+- Detect real client IP from X-Forwarded-For headers or proxy protocol
+- Scope policies to a specific listener via `sectionName`
+- List, inspect, and update policies across a project
+- Preview changes before applying with `datumctl diff`
+- Delete policies safely
+- Check permissions before acting
+
+## How it relates to other Datum surfaces
+
+- **Product docs:** [AI Edge](/ai-edge/overview) — the human-facing reference for gateways and edge policies
+- **Datum MCP:** [Datum MCP](/datum-mcp) — for agents that need live read/write access to gateway resources during a session
+- **`datumctl`:** [datumctl overview](/datumctl/overview) — `get`, `describe`, `apply`, `diff`, `delete` commands the skill teaches agents to use
+
+## View the full skill
+
+The canonical SKILL.md lives in the [datum-cloud/skills](https://github.com/datum-cloud/skills) repo:
+
+<CardGroup cols={2}>
+  <Card
+    title="On GitHub"
+    icon="github"
+    href="https://github.com/datum-cloud/skills/blob/main/skills/client-traffic/SKILL.md"
+  >
+    Browse the skill source, including frontmatter and full instructions.
+  </Card>
+  <Card
+    title="Raw SKILL.md"
+    icon="file-code"
+    href="https://raw.githubusercontent.com/datum-cloud/skills/main/skills/client-traffic/SKILL.md"
+  >
+    Direct URL for agents that fetch skills by URL.
+  </Card>
+</CardGroup>

--- a/agents/skills/dns.mdx
+++ b/agents/skills/dns.mdx
@@ -1,0 +1,69 @@
+---
+title: "DNS skill"
+description: "Teach agents to manage DNS zones and record sets in Datum Cloud using datumctl."
+---
+
+The DNS skill helps agents manage [DNS](/domain-dns/dns) zones and record sets in Datum Cloud — creating, inspecting, updating, and deleting `DNSZone` and `DNSRecordSet` resources within a project. It covers all supported record types (A, AAAA, CNAME, MX, TXT, ALIAS, CAA, SRV, and more) and teaches agents to validate propagation after changes.
+
+## Install
+
+<CodeGroup>
+
+```bash Claude Code
+/plugin marketplace add datum-cloud/skills
+/plugin install datum-cloud@datum-cloud
+```
+
+```bash npx skills
+npx skills add https://github.com/datum-cloud/skills
+```
+
+```bash Cursor
+# Settings → Rules → Add Rule → Remote Rule (GitHub)
+# Repository: datum-cloud/skills
+```
+
+</CodeGroup>
+
+<Note>
+Once installed, the skill activates automatically when you ask an agent to work with DNS on Datum. No further configuration needed.
+</Note>
+
+## Capabilities
+
+- List and describe DNS zones in a project
+- Create DNS zones from YAML manifests
+- Manage DNS record sets (A, AAAA, CNAME, MX, TXT, ALIAS, CAA, SRV, and more)
+- Set and update TTL per record entry
+- Apply changes idempotently
+- Preview changes before applying with `datumctl diff`
+- Delete DNS zones and record sets safely
+- Validate DNS propagation via status conditions and external `dig` queries
+- Check permissions before acting
+
+## How it relates to other Datum surfaces
+
+- **Product docs:** [DNS](/domain-dns/dns) — the human-facing reference for DNS zones and records
+- **Datum MCP:** [Datum MCP](/datum-mcp) — for agents that need live read/write access to DNS resources during a session
+- **`datumctl`:** [datumctl overview](/datumctl/overview) — `get`, `describe`, `apply`, `diff`, `delete` commands the skill teaches agents to use
+
+## View the full skill
+
+The canonical SKILL.md lives in the [datum-cloud/skills](https://github.com/datum-cloud/skills) repo:
+
+<CardGroup cols={2}>
+  <Card
+    title="On GitHub"
+    icon="github"
+    href="https://github.com/datum-cloud/skills/blob/main/skills/dns/SKILL.md"
+  >
+    Browse the skill source, including frontmatter and full instructions.
+  </Card>
+  <Card
+    title="Raw SKILL.md"
+    icon="file-code"
+    href="https://raw.githubusercontent.com/datum-cloud/skills/main/skills/dns/SKILL.md"
+  >
+    Direct URL for agents that fetch skills by URL.
+  </Card>
+</CardGroup>

--- a/agents/skills/domains.mdx
+++ b/agents/skills/domains.mdx
@@ -1,0 +1,67 @@
+---
+title: "Domains skill"
+description: "Teach agents to attach and verify domains in Datum Cloud projects using datumctl."
+---
+
+The Domains skill helps agents manage [domain](/domain-dns/domains) resources in Datum Cloud — attaching domains to projects, retrieving verification tokens (DNS record or HTTP token), and applying changes idempotently. It teaches agents the correct workflow: apply the manifest, then check `status.verification` for the challenge before confirming ownership.
+
+## Install
+
+<CodeGroup>
+
+```bash Claude Code
+/plugin marketplace add datum-cloud/skills
+/plugin install datum-cloud@datum-cloud
+```
+
+```bash npx skills
+npx skills add https://github.com/datum-cloud/skills
+```
+
+```bash Cursor
+# Settings → Rules → Add Rule → Remote Rule (GitHub)
+# Repository: datum-cloud/skills
+```
+
+</CodeGroup>
+
+<Note>
+Once installed, the skill activates automatically when you ask an agent to work with Domains on Datum. No further configuration needed.
+</Note>
+
+## Capabilities
+
+- List and describe domains in a project
+- Attach domains to services via YAML manifests
+- Apply changes idempotently
+- Preview changes before applying with `datumctl diff`
+- Delete domains
+- Retrieve domain verification tokens (`status.verification.dnsRecord` or `status.verification.httpToken`)
+- Check permissions before acting
+
+## How it relates to other Datum surfaces
+
+- **Product docs:** [Domains](/domain-dns/domains) — the human-facing reference for domain management
+- **Datum MCP:** [Datum MCP](/datum-mcp) — for agents that need live read/write access to domain resources during a session
+- **`datumctl`:** [datumctl overview](/datumctl/overview) — `get`, `describe`, `apply`, `diff`, `delete` commands the skill teaches agents to use
+
+## View the full skill
+
+The canonical SKILL.md lives in the [datum-cloud/skills](https://github.com/datum-cloud/skills) repo:
+
+<CardGroup cols={2}>
+  <Card
+    title="On GitHub"
+    icon="github"
+    href="https://github.com/datum-cloud/skills/blob/main/skills/domains/SKILL.md"
+  >
+    Browse the skill source, including frontmatter and full instructions.
+  </Card>
+  <Card
+    title="Raw SKILL.md"
+    icon="file-code"
+    href="https://raw.githubusercontent.com/datum-cloud/skills/main/skills/domains/SKILL.md"
+  >
+    Direct URL for agents that fetch skills by URL.
+  </Card>
+</CardGroup>

--- a/agents/skills/httproute.mdx
+++ b/agents/skills/httproute.mdx
@@ -1,0 +1,71 @@
+---
+title: "HTTPRoute skill"
+description: "Teach agents to configure HTTP routing rules — path matching, traffic splitting, redirects, rewrites, and header manipulation on Datum Cloud."
+---
+
+The HTTPRoute skill helps agents configure HTTP routing rules in Datum Cloud. It covers [AI Edge](/ai-edge/overview) route definitions — matching requests by path, headers, method, and query parameters, then forwarding, splitting, redirecting, rewriting, or mirroring traffic using `HTTPRoute` resources attached to a Gateway.
+
+## Install
+
+<CodeGroup>
+
+```bash Claude Code
+/plugin marketplace add datum-cloud/skills
+/plugin install datum-cloud@datum-cloud
+```
+
+```bash npx skills
+npx skills add https://github.com/datum-cloud/skills
+```
+
+```bash Cursor
+# Settings → Rules → Add Rule → Remote Rule (GitHub)
+# Repository: datum-cloud/skills
+```
+
+</CodeGroup>
+
+<Note>
+Once installed, the skill activates automatically when you ask an agent to configure HTTP routing on Datum. No further configuration needed.
+</Note>
+
+## Capabilities
+
+- Route traffic by path (exact, prefix, regex), HTTP method, headers, and query parameters
+- Split traffic across multiple backends by weight (canary, A/B, blue-green deployments)
+- Redirect HTTP to HTTPS and issue permanent or temporary redirects
+- Rewrite URL paths and hostnames before forwarding to backends
+- Add, set, or remove request and response headers per route rule
+- Mirror (shadow) a percentage of traffic to a secondary backend without affecting responses
+- Configure per-route request and backend timeouts
+- List, inspect, and update routes across a project
+- Preview changes before applying with `datumctl diff`
+- Delete routes safely
+- Check permissions before acting
+
+## How it relates to other Datum surfaces
+
+- **Product docs:** [AI Edge](/ai-edge/overview) — the human-facing reference for gateways and routing
+- **Datum MCP:** [Datum MCP](/datum-mcp) — for agents that need live read/write access to HTTPRoute resources during a session
+- **`datumctl`:** [datumctl overview](/datumctl/overview) — `get`, `describe`, `apply`, `diff`, `delete` commands the skill teaches agents to use
+
+## View the full skill
+
+The canonical SKILL.md lives in the [datum-cloud/skills](https://github.com/datum-cloud/skills) repo:
+
+<CardGroup cols={2}>
+  <Card
+    title="On GitHub"
+    icon="github"
+    href="https://github.com/datum-cloud/skills/blob/main/skills/httproute/SKILL.md"
+  >
+    Browse the skill source, including frontmatter and full instructions.
+  </Card>
+  <Card
+    title="Raw SKILL.md"
+    icon="file-code"
+    href="https://raw.githubusercontent.com/datum-cloud/skills/main/skills/httproute/SKILL.md"
+  >
+    Direct URL for agents that fetch skills by URL.
+  </Card>
+</CardGroup>

--- a/agents/skills/index.mdx
+++ b/agents/skills/index.mdx
@@ -1,0 +1,49 @@
+---
+title: "Overview"
+description: "Self-contained instructions that teach AI agents how to perform Datum Cloud tasks."
+---
+
+Skills are folders containing a `SKILL.md` file with metadata and step-by-step instructions. Agents discover and load them on demand — no scaffolding, no config files. Datum's official skills cover the most common operations across AI Edge, DNS, Domains, and Metrics Export, with more on the way.
+
+These skills work with any agent with support for Skills like but not limited to: Claude, Codex, Cursor, Pi, OpenCode, Mistral Vibe.
+
+## Install
+
+Datum's skills live at **[github.com/datum-cloud/skills](https://github.com/datum-cloud/skills)**. Install for your agent of choice:
+
+<CodeGroup>
+
+```bash Claude Code
+/plugin marketplace add datum-cloud/skills
+/plugin install datum-cloud@datum-cloud
+```
+
+```bash npx skills
+npx skills add https://github.com/datum-cloud/skills
+```
+
+```bash Cursor
+# Settings → Rules → Add Rule → Remote Rule (GitHub)
+# Repository: datum-cloud/skills
+```
+
+</CodeGroup>
+
+## Available skills
+
+| Skill | Covers | Resources |
+|---|---|---|
+| [AI Edge](/agents/skills/ai-edge) | WAF, traffic protection, auth policies | TrafficProtectionPolicy, SecurityPolicy, BackendTrafficPolicy, Gateway, HTTPRoute |
+| [Client Traffic](/agents/skills/client-traffic) | TLS termination, HTTP/3, connection limits | ClientTrafficPolicy, Gateway |
+| [DNS](/agents/skills/dns) | Zones and records | DNSZone, DNSRecordSet, DNSZoneClass |
+| [Domains](/agents/skills/domains) | Domain attachment and verification | Domain |
+| [HTTPRoute](/agents/skills/httproute) | Path routing, traffic splitting, redirects, rewrites | HTTPRoute, Gateway |
+| [Metrics Export](/agents/skills/metrics-export) | Prometheus remote write pipelines | ExportPolicy |
+
+## How skills work alongside Datum MCP and datumctl
+
+Skills tell the agent *how* to think about a Datum resource — the canonical patterns, the right flags, the order of operations. Datum MCP and `datumctl` are *how* the agent acts. A skill might instruct "always preview HTTPProxy changes with `--dry-run` before applying" — the agent then uses `datumctl` to actually run the command. See [Agents Overview](/agents/overview) for the full picture.
+
+## Contributing
+
+Found something missing or wrong? Skills are open-source (Apache-2.0) and accept community contributions. See the [contributing guide](https://github.com/datum-cloud/skills/blob/main/CONTRIBUTING.md) or open an issue at [github.com/datum-cloud/skills/issues](https://github.com/datum-cloud/skills/issues).

--- a/agents/skills/metrics-export.mdx
+++ b/agents/skills/metrics-export.mdx
@@ -1,0 +1,68 @@
+---
+title: "Metrics Export skill"
+description: "Teach agents to configure Prometheus remote write pipelines in Datum Cloud using ExportPolicy resources."
+---
+
+The Metrics Export skill helps agents configure [metrics export](/platform/metrics-export) pipelines in Datum Cloud — defining named sources (with optional MetricsQL filters) and sinks (Prometheus remote write endpoints) to ship project metrics to external observability platforms such as Grafana Cloud. It teaches agents the correct manifest structure, credential handling via Secrets, and per-sink health validation.
+
+## Install
+
+<CodeGroup>
+
+```bash Claude Code
+/plugin marketplace add datum-cloud/skills
+/plugin install datum-cloud@datum-cloud
+```
+
+```bash npx skills
+npx skills add https://github.com/datum-cloud/skills
+```
+
+```bash Cursor
+# Settings → Rules → Add Rule → Remote Rule (GitHub)
+# Repository: datum-cloud/skills
+```
+
+</CodeGroup>
+
+<Note>
+Once installed, the skill activates automatically when you ask an agent to work with Metrics Export on Datum. No further configuration needed.
+</Note>
+
+## Capabilities
+
+- List and describe export policies in a project
+- Create metrics export pipelines from YAML manifests
+- Filter exported metrics using MetricsQL selector expressions
+- Configure Prometheus remote write endpoints with Secret-backed credentials
+- Tune batching and retry behavior per sink
+- Apply changes idempotently
+- Preview changes before applying with `datumctl diff`
+- Delete export policies safely
+
+## How it relates to other Datum surfaces
+
+- **Product docs:** [Metrics Export](/platform/metrics-export) — the human-facing reference for the export pipeline and ExportPolicy resource
+- **Datum MCP:** [Datum MCP](/datum-mcp) — for agents that need live read/write access to export policies during a session
+- **`datumctl`:** [datumctl overview](/datumctl/overview) — `get`, `describe`, `apply`, `diff`, `delete` commands the skill teaches agents to use
+
+## View the full skill
+
+The canonical SKILL.md lives in the [datum-cloud/skills](https://github.com/datum-cloud/skills) repo:
+
+<CardGroup cols={2}>
+  <Card
+    title="On GitHub"
+    icon="github"
+    href="https://github.com/datum-cloud/skills/blob/main/skills/metrics-export/SKILL.md"
+  >
+    Browse the skill source, including frontmatter and full instructions.
+  </Card>
+  <Card
+    title="Raw SKILL.md"
+    icon="file-code"
+    href="https://raw.githubusercontent.com/datum-cloud/skills/main/skills/metrics-export/SKILL.md"
+  >
+    Direct URL for agents that fetch skills by URL.
+  </Card>
+</CardGroup>

--- a/ai-edge/overview.mdx
+++ b/ai-edge/overview.mdx
@@ -4,6 +4,10 @@ sidebarTitle: "Overview"
 description: "Datum's AI Edge service is built on Envoy and provides an intelligent HTTPProxy along with a Coraza-based Web Application Firewall (WAF) to help you protect and route internet traffic to your backend services."
 ---
 
+<Note>
+**Working with this resource via an AI agent?** Datum publishes three skills covering AI Edge: [AI Edge](/agents/skills/ai-edge) (WAF, auth, and traffic policies), [Client Traffic](/agents/skills/client-traffic) (TLS termination, HTTP/3, connection limits), and [HTTPRoute](/agents/skills/httproute) (path routing, traffic splitting, redirects).
+</Note>
+
 Our AI Edge service is built on Envoy and provides an intelligent HTTPProxy along with a Coraza-based Web Application Firewall (WAF).
 
 AI Edges help you protect and route internet traffic to your backend services. We support HTTP(S) 1.1, HTTP2, gRPC, and WebSockets.

--- a/docs.json
+++ b/docs.json
@@ -103,10 +103,29 @@
             ]
           },
           {
+            "group": "Agents",
+            "pages": [
+              "agents/overview",
+              {
+                "group": "Skills",
+                "pages": [
+                  "agents/skills/index",
+                  "agents/skills/ai-edge",
+                  "agents/skills/client-traffic",
+                  "agents/skills/dns",
+                  "agents/skills/domains",
+                  "agents/skills/httproute",
+                  "agents/skills/metrics-export"
+                ]
+              },
+              "datum-mcp",
+              "agents/llms-txt"
+            ]
+          },
+          {
             "group": "Tools",
             "pages": [
-              "desktop-apps",
-              "datum-mcp"
+              "desktop-apps"
             ]
           }
         ]

--- a/domain-dns/dns.mdx
+++ b/domain-dns/dns.mdx
@@ -3,6 +3,10 @@ title: "DNS"
 description: "We offer authoritative DNS hosting for your domains that you can manage through the Datum Cloud portal as well as CLI."
 ---
 
+<Note>
+**Working with this resource via an AI agent?** Datum publishes a [DNS skill](/agents/skills/dns) that teaches agents the canonical patterns for this resource.
+</Note>
+
 We offer authoritative DNS hosting for your domains that you can manage through our portal as well as CLI.
 
 ## Current features

--- a/domain-dns/domains.mdx
+++ b/domain-dns/domains.mdx
@@ -3,6 +3,10 @@ title: "Domains"
 description: "Track your domains in one place regardless of where they are registered to gain programmatic access to foundational infrastructure components."
 ---
 
+<Note>
+**Working with this resource via an AI agent?** Datum publishes a [Domains skill](/agents/skills/domains) that teaches agents the canonical patterns for this resource.
+</Note>
+
 At Datum, domains are just another type of resource.
 
 By tracking your domains in one place (regardless of where they are registered or where DNS is hosted), you and your colleagues gain programmatic access to a foundational component of your infrastructure. No more spreadsheets!

--- a/index.mdx
+++ b/index.mdx
@@ -17,7 +17,6 @@ sidebarTitle: "Introduction"
 <CardGroup cols={3}>
   <Card title="Set Up Your Account" icon="user-plus" href="/platform/setup" />
   <Card title="Install datumctl" icon="terminal" href="/datumctl/overview" />
-  <Card title="Desktop Apps" icon="display" href="/desktop-apps" />
 </CardGroup>
 
 ## Explore
@@ -38,11 +37,13 @@ sidebarTitle: "Introduction"
   <Card title="DNS" icon="server" href="/domain-dns/dns">
     Manage DNS records for your domains and services.
   </Card>
+  <Card title="Agents" icon="robot" href="/agents/overview">
+    Skills, MCP, llms.txt, and datumctl — everything AI agents need to work with Datum.
+  </Card>
 </CardGroup>
 
-## Tools & reference
+## Tools
 
 <CardGroup cols={3}>
-  <Card title="CLI Commands" icon="rectangle-list" href="/cli/options" />
-  <Card title="Locations" icon="location-dot" href="/platform/locations" />
+  <Card title="Desktop Apps" icon="display" href="/desktop-apps" />
 </CardGroup>

--- a/platform/metrics-export.mdx
+++ b/platform/metrics-export.mdx
@@ -3,6 +3,10 @@ title: "Metrics Export"
 description: "Datum collects OpenTelemetry metrics from your Datum infrastructure services, giving visibility into the performance and health of your workloads."
 ---
 
+<Note>
+**Working with this resource via an AI agent?** Datum publishes a [Metrics Export skill](/agents/skills/metrics-export) that teaches agents the canonical patterns for this resource.
+</Note>
+
 Datum provides baseline "proof of life" dashboards in the Datum Cloud portal, but you may prefer to view Datum telemetry alongside your other metrics.
 
 We collect OpenTelemetry metrics from your Datum infrastructure and services, giving you visibility into the performance and health of your workloads.


### PR DESCRIPTION
## Summary

- Adds a new **Agents** sidebar group (Overview, Skills, Datum MCP, llms.txt) above Tools in `docs.json`
- Slims **Tools** group to Desktop Apps only (Datum MCP moved to Agents)
- Creates 9 new pages under `agents/`:
  - `agents/overview.mdx` — four agent surfaces (Skills, MCP, llms.txt, datumctl)
  - `agents/llms-txt.mdx` — documents the live llms.txt index
  - `agents/skills/index.mdx` — install instructions + skills table
  - Six per-skill pages sourced directly from [datum-cloud/skills](https://github.com/datum-cloud/skills) SKILL.md files:
    - [`ai-edge`](https://github.com/datum-cloud/skills/blob/main/skills/ai-edge/SKILL.md) → `agents/skills/ai-edge.mdx`
    - [`client-traffic`](https://github.com/datum-cloud/skills/blob/main/skills/client-traffic/SKILL.md) → `agents/skills/client-traffic.mdx`
    - [`dns`](https://github.com/datum-cloud/skills/blob/main/skills/dns/SKILL.md) → `agents/skills/dns.mdx`
    - [`domains`](https://github.com/datum-cloud/skills/blob/main/skills/domains/SKILL.md) → `agents/skills/domains.mdx`
    - [`httproute`](https://github.com/datum-cloud/skills/blob/main/skills/httproute/SKILL.md) → `agents/skills/httproute.mdx`
    - [`metrics-export`](https://github.com/datum-cloud/skills/blob/main/skills/metrics-export/SKILL.md) → `agents/skills/metrics-export.mdx`
- Adds agent `<Note>` callouts to `ai-edge/overview`, `domain-dns/dns`, `domain-dns/domains`, and `platform/metrics-export`
- Updates landing page (`index.mdx`): renames Tools & reference → Tools, adds Agents card to Explore section

## Test plan

- [ ] Staging preview shows Agents group above Tools in sidebar
- [ ] All six skill pages render with correct Capabilities bullets matching their source SKILL.md
- [ ] Skills sidebar children are ordered alphabetically (AI Edge, Client Traffic, DNS, Domains, HTTPRoute, Metrics Export)
- [ ] Datum MCP link under Agents resolves to existing page (URL unchanged)
- [ ] `agents/llms-txt` page reflects actual llms.txt content
- [ ] Note callouts on product pages link correctly to skill pages
- [ ] Landing page Explore section shows Agents as last card
- [ ] Tools group contains only Desktop Apps

Closes #697