### PR TITLE
fix: update login command from datumctl auth login to datumctl login

### DIFF
--- a/cli/datumctl_auth.md
+++ b/cli/datumctl_auth.md
@@ -41,7 +41,7 @@ Authenticate with Datum Cloud
 * [datumctl auth can-i](/docs/datumctl/command/datumctl_auth_can-i/)	 - Check whether an action is allowed
 * [datumctl auth get-token](/docs/datumctl/command/datumctl_auth_get-token/)	 - Retrieve access token for active user (raw or K8s format)
 * [datumctl auth list](/docs/datumctl/command/datumctl_auth_list/)	 - List locally authenticated users
-* [datumctl auth login](/docs/datumctl/command/datumctl_auth_login/)	 - Authenticate with Datum Cloud via OAuth2 PKCE flow
+* [datumctl login](/docs/datumctl/command/datumctl_login/)	 - Authenticate with Datum Cloud via OAuth2 PKCE flow
 * [datumctl auth logout](/docs/datumctl/command/datumctl_auth_logout/)	 - Remove local authentication credentials for a specified user or all users
 * [datumctl auth switch](/docs/datumctl/command/datumctl_auth_switch/)	 - Set the active authenticated user session
 * [datumctl auth update-kubeconfig](/docs/datumctl/command/datumctl_auth_update-kubeconfig/)	 - Update the kubeconfig file

--- a/datumctl/authentication.mdx
+++ b/datumctl/authentication.mdx
@@ -10,7 +10,7 @@ description: "datumctl uses OAuth 2.0 and OpenID Connect (OIDC) with PKCE for se
 You authenticate through your browser, and `datumctl` stores your credentials securely in your system keyring. To get started, run the following command, which opens your browser and guides you through authentication.
 
 ```text
-datumctl auth login
+datumctl login
 ```
 
 To see which users you have authenticated locally, use the `list` command:
@@ -22,7 +22,7 @@ datumctl auth list
 
 This will output a table showing the Name, Email, and Status (Active or blank) for each set of stored credentials.  Other authentication commands include:
 
-- `datumctl auth login`
+- `datumctl login`
 - `datumctl auth list`
 - `datumctl auth logout`
 - `datumctl auth get-token`

--- a/platform/service-accounts.mdx
+++ b/platform/service-accounts.mdx
@@ -84,7 +84,7 @@ When you create a datum-managed key, Datum returns a JSON credentials file:
 ### datumctl
 
 ```text
-datumctl auth login --credentials-file /path/to/credentials.json
+datumctl login --credentials-file /path/to/credentials.json
 ```
 
 Or set the environment variable so all subsequent commands pick it up automatically:


### PR DESCRIPTION
## Summary

- Updates all doc references to the login command from `datumctl auth login` to `datumctl login`
- Affects three files: the authentication guide, the service accounts page, and the CLI reference

## Files changed

- `datumctl/authentication.mdx` — two occurrences updated (code block and command list)
- `platform/service-accounts.mdx` — credential file login example updated
- `cli/datumctl_auth.md` — CLI reference link and label updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)