### PR TITLE
docs: clarify relationship between /datumctl and /cli sections

### DIFF
--- a/cli/options.mdx
+++ b/cli/options.mdx
@@ -6,6 +6,10 @@ description: A CLI for interacting with the Datum platform
 
 Global options available on all `datumctl` commands.
 
+<Info>
+  This section is the flag-level command reference. For concepts, authentication, and workflows, see the [datumctl overview](/datumctl/overview).
+</Info>
+
 ### Options
 
 | Flag | Type | Description |

--- a/datumctl/overview.mdx
+++ b/datumctl/overview.mdx
@@ -10,6 +10,13 @@ description: "High level overview of the Datum Cloud CLI."
   Ready to play? Download and install via [our downloads page](https://www.datum.net/download/datumctl/).
 </Info>
 
+## How these docs are organized
+
+`datumctl` documentation is split into two sections:
+
+- **datumctl** (this section) covers concepts, authentication, and workflows — start here to learn how the CLI works.
+- **[CLI Commands](/cli/options)** contains the full flag-level reference for each command (`datumctl apply`, `datumctl get`, and so on).
+
 ## Design goals
 
 `datumctl` is designed with a few core principles in mind:


### PR DESCRIPTION
## Summary

- Adds a "How these docs are organized" section to `/datumctl/overview` explaining that `/datumctl/*` covers concepts/auth/workflows while `/cli/*` is the flag-level command reference.
- Adds a reciprocal cross-link from `/cli/options` back to the datumctl overview.
- Pure content change — no navigation (`docs.json`) edits.

Closes #14.

## Test plan

- [x] Mintlify preview renders both pages without errors
- [x] Link `/datumctl/overview` → `/cli/options` resolves
- [x] Link `/cli/options` → `/datumctl/overview` resolves
- [x] Sidebar navigation is unchanged