### PR TITLE
Expand & cross-link the datumctl CLI documentation

### DIFF
--- a/datum-mcp.mdx
+++ b/datum-mcp.mdx
@@ -16,6 +16,10 @@ Datum MCP integrates with popular AI assistants like Cursor, enabling you to vie
 
 Datum MCP implements the latest [MCP Authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) specifications and supports OAuth 2.1 (PKCE) auth or macOS Keychain token storage.
 
+<Info>
+  Prefer to stay in the terminal? `datumctl` has a built-in assistant that answers questions in natural language without a separate MCP client — see [Ask datumctl in natural language and connect MCP clients](/datumctl/ai-and-mcp).
+</Info>
+
 **Install** - We offer three ways to get started:
 
 1. Quick install

--- a/datumctl/activity.mdx
+++ b/datumctl/activity.mdx
@@ -25,7 +25,8 @@ logs to understand what's happening within your organization and projects.
 ### Project and organization audit logs
 
 Use the `--project` and `--organization` flag to control which context audit
-logs are retrieved from.
+logs are retrieved from. These flags follow the same scope rules as the rest of
+the CLI — see [Contexts & scoping](/datumctl/contexts-and-scoping).
 
 ```bash
 $ datumctl activity query --project datum-cloud
@@ -126,3 +127,9 @@ items:
 kind: EventList
 metadata: {}
 ```
+
+## Related
+
+- [Interactive console](/datumctl/console) — browse the same audit activity in the console's activity dashboard.
+- [Output formats & scripting](/datumctl/output-and-scripting) — reshape `-o json`/`-o yaml` activity output and wire it into automation.
+- [Contexts & scoping](/datumctl/contexts-and-scoping) — how `--project` and `--organization` select which control plane the query runs against.

--- a/datumctl/ai-and-mcp.mdx
+++ b/datumctl/ai-and-mcp.mdx
@@ -1,0 +1,282 @@
+---
+title: "AI assistant & MCP"
+sidebarTitle: "AI & MCP"
+description: "Ask datumctl questions in natural language, and connect Datum Cloud to MCP-aware AI clients."
+---
+
+`datumctl` can translate natural language into Datum Cloud operations. Ask it a
+question — "list all DNS zones", "which projects am I in?" — and the assistant
+figures out which resources to read and shows you the answer. When it wants to
+make a change, it always pauses and asks you to confirm first.
+
+This guide covers the `datumctl ai` command for terminal use, and how to connect
+Datum Cloud to MCP-aware AI clients such as Claude Desktop and Cursor.
+
+<Info>
+  The assistant reasons over your resources through a large language model, so
+  you supply your own model API key (Anthropic, OpenAI, or Gemini). Your key and
+  requests go directly to the provider you choose.
+</Info>
+
+## Before you start
+
+You need two things:
+
+1. **A logged-in `datumctl`.** The assistant reads and writes real Datum Cloud
+   resources, so you must be authenticated. Run `datumctl login` first.
+2. **A model API key** for Anthropic, OpenAI, or Gemini.
+
+## Quick start
+
+<Steps>
+  <Step title="Log in">
+    ```bash
+    datumctl login
+    ```
+  </Step>
+  <Step title="Save a model API key">
+    Store the key once so you don't have to export it in every shell:
+
+    ```bash
+    datumctl ai config set anthropic_api_key sk-ant-...
+    ```
+  </Step>
+  <Step title="Set a default scope (optional)">
+    Point the assistant at the organization or project you work in most:
+
+    ```bash
+    datumctl ai config set organization my-org-id
+    ```
+  </Step>
+  <Step title="Ask a question">
+    ```bash
+    datumctl ai "list all DNS zones"
+    ```
+  </Step>
+</Steps>
+
+## Asking questions
+
+### One-shot questions
+
+Pass your question as an argument to get a single answer and return to your
+shell:
+
+```bash
+datumctl ai "how many projects are in my organization?"
+```
+
+You can also pipe a question in on standard input, which is handy in scripts:
+
+```bash
+echo "list projects" | datumctl ai
+```
+
+<Note>
+  When input is piped in (no terminal attached), the assistant answers questions
+  but will not perform any write — mutating actions are skipped because they
+  can't be confirmed. See [The confirmation gate](#the-confirmation-gate).
+</Note>
+
+### Interactive session
+
+Run `datumctl ai` with no question to start an interactive REPL. The assistant
+keeps conversation context, so you can ask follow-up questions that build on
+earlier answers:
+
+```bash
+datumctl ai --project my-project-id
+```
+
+At the `>` prompt, type your next question. Type `exit` or `quit` (or press
+Enter on an empty line) to leave the session.
+
+## Choosing scope
+
+The assistant needs to know which control plane to operate against. You can set
+scope three ways, from most to least specific:
+
+<Tabs>
+  <Tab title="Per-invocation flags">
+    ```bash
+    datumctl ai "list projects" --organization other-org-id
+    datumctl ai --project my-project-id
+    ```
+  </Tab>
+  <Tab title="Active datumctl context">
+    If you've selected a context with `datumctl ctx use`, the assistant uses it
+    automatically — no flags needed.
+  </Tab>
+  <Tab title="Saved ai defaults">
+    ```bash
+    datumctl ai config set organization my-org-id
+    datumctl ai config set project my-project-id
+    ```
+  </Tab>
+</Tabs>
+
+Scope is resolved in this order: **command-line flags → environment variables →
+active `datumctl` context → saved `ai` config defaults.** Because the active
+context wins over saved `ai` defaults, switching with `datumctl ctx use` is
+respected without having to clear your `ai config` values. This mirrors how every
+other command resolves scope — see [Contexts & scoping](/datumctl/contexts-and-scoping).
+
+A few rules:
+
+- `--organization` and `--project` are mutually exclusive — set one, not both.
+- `--namespace` sets the default namespace for the session (defaults to
+  `default`).
+- `--platform-wide` targets the platform root instead of a single org or
+  project. This is a staff-only mode and can't be combined with
+  `--organization` or `--project`.
+
+If no scope is set at all, the assistant still runs, but without resource tools —
+it can chat, but can't read or change anything until you give it an organization
+or project.
+
+## The confirmation gate
+
+Reads and writes are treated very differently:
+
+- **Read operations run immediately.** Listing, getting, and describing
+  resources happen without a prompt.
+- **Write operations always pause for confirmation.** Before creating, updating,
+  or deleting anything, the assistant prints a preview of the exact action and
+  asks you to approve it.
+
+The preview shows the tool and the full arguments, then waits for your answer:
+
+```text
+--- Proposed action ---
+Tool:    ...
+Details:
+{
+  ...
+}
+-----------------------
+Apply changes? [y/N]: 
+```
+
+Only an explicit `y` proceeds; anything else declines.
+
+<Warning>
+  When `datumctl ai` is run without an attached terminal (for example, with a
+  piped question or in CI), write operations are automatically declined and
+  skipped. Perform mutations only from an interactive terminal session.
+</Warning>
+
+## Configuration
+
+Saved settings provide defaults for every `datumctl ai` invocation, so you don't
+have to repeat flags or export environment variables.
+
+```bash
+# Set a value
+datumctl ai config set organization my-org-id
+
+# Show the current configuration (API keys are redacted)
+datumctl ai config show
+
+# Remove a value
+datumctl ai config unset organization
+```
+
+### Configuration keys
+
+| Key | Purpose |
+| --- | --- |
+| `organization` | Default organization ID (overridden by `--organization`) |
+| `project` | Default project ID (overridden by `--project`) |
+| `namespace` | Default namespace (defaults to `default`) |
+| `provider` | LLM provider: `anthropic`, `openai`, or `gemini` |
+| `model` | Model override, e.g. `claude-sonnet-4-6`, `gpt-4o`, `gemini-2.0-flash` |
+| `max_iterations` | Agentic loop iteration cap (default `20`) |
+| `anthropic_api_key` | Anthropic API key |
+| `openai_api_key` | OpenAI API key |
+| `gemini_api_key` | Gemini API key |
+
+### Where settings are stored
+
+Configuration lives in a YAML file:
+
+- **macOS / Linux:** `~/.config/datumctl/ai.yaml`
+- **Windows:** `%AppData%\datumctl\ai.yaml`
+
+Run `datumctl ai config show` to print the resolved path along with your current
+values.
+
+### Precedence and environment variables
+
+- **Flags always win** over config file values for a single invocation.
+- **API keys** can also come from environment variables, which override any key
+  stored in the config file:
+
+  ```bash
+  export ANTHROPIC_API_KEY=sk-ant-...
+  export OPENAI_API_KEY=...
+  export GEMINI_API_KEY=...
+  ```
+
+This lets you keep a default key in the config file for everyday use and
+temporarily override it per shell when needed.
+
+## Choosing a provider and model
+
+You don't have to set a provider explicitly — the assistant selects one using
+this order:
+
+1. **Model name prefix.** `claude-*` → Anthropic, `gpt-*` / `o1*` / `o3*` →
+   OpenAI, `gemini-*` → Gemini.
+2. **An explicit `provider` setting**, if you set one.
+3. **Whichever API key is available** (environment variable first, then config
+   file).
+
+Set a model per invocation with `--model`, or save one as a default:
+
+```bash
+datumctl ai config set model claude-sonnet-4-6
+datumctl ai "list dnszones" --model gpt-4o
+```
+
+Each provider has a sensible default model if you don't pick one:
+`claude-sonnet-4-6` for Anthropic, `gpt-4o` for OpenAI, and `gemini-2.0-flash`
+for Gemini.
+
+## Connecting MCP clients
+
+The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) lets AI
+clients like Claude Desktop and Cursor talk to your Datum Cloud resources
+directly, outside the terminal. Datum publishes an official **Datum MCP server**
+for this — a standalone binary you point your MCP-aware client at.
+
+Where `datumctl ai` is the interactive, terminal-first experience, the Datum MCP
+server is the bridge that gives a desktop AI assistant secure, standards-based
+access to organizations, projects, domains, proxies, DNS, and more.
+
+A minimal stdio client configuration looks like this:
+
+```json
+{
+  "datum-mcp": {
+    "command": "datum-mcp",
+    "args": []
+  }
+}
+```
+
+On first use, the server runs a browser-based OAuth (PKCE) sign-in and caches
+credentials securely, refreshing them automatically on later calls — the same
+security model `datumctl` uses for [authentication](/datumctl/authentication).
+
+<Info>
+  Installation, the full tool catalog, and one-click setup for clients such as
+  Cursor are covered on the dedicated [Datum MCP](/datum-mcp) page, and upstream
+  in the [Datum MCP repository](https://github.com/datum-cloud/datum-mcp).
+</Info>
+
+## Related
+
+- [Authentication](/datumctl/authentication) — set up credentials before your first question.
+- [Datum MCP](/datum-mcp) — connect a desktop AI client such as Claude Desktop or Cursor to Datum Cloud with the Datum MCP server.
+- [Contexts & scoping](/datumctl/contexts-and-scoping) — how the assistant decides which organization or project to operate against.
+- [Overview](/datumctl/overview) — new to the CLI? Start here to see how `datumctl` is structured.

--- a/datumctl/authentication.mdx
+++ b/datumctl/authentication.mdx
@@ -26,7 +26,7 @@ This outputs a table showing the Name, Email, and Status (Active or blank) for e
 - `datumctl auth list`
 - `datumctl auth logout`
 - `datumctl auth get-token`
-- `datumctl auth update-kubeconfig`
+- `datumctl auth update-kubeconfig` — for existing kubectl users only; see [using datumctl with kubectl (kubectl interop)](/datumctl/kubectl-interop)
 - `datumctl auth switch`
 
 ## Switching active user
@@ -39,7 +39,7 @@ datumctl auth switch <user-email>
 
 Replace `<user-email>` with the email address of the user you want to make active. This user must already be logged in.
 
-After switching, subsequent commands that require authentication (like `datumctl organizations list` or `kubectl` operations configured via `update-kubeconfig`) will use the credentials of the newly activated user.
+After switching, subsequent commands that require authentication (like `datumctl get organizations`) use the credentials of the newly activated user. Each user has its own set of discovered contexts, so your active organization or project follows the account you switch to — see [Contexts & scoping](/datumctl/contexts-and-scoping).
 
 ## Logging out
 
@@ -56,3 +56,10 @@ To remove all Datum Cloud credentials stored by `datumctl` in your keyring, use 
 ```text
 datumctl auth logout --all
 ```
+
+## Related
+
+- [Quickstart](/datumctl/quickstart) — install `datumctl` and log in for the first time.
+- [Contexts & scoping](/datumctl/contexts-and-scoping) — how the account you're signed in as maps to the organizations and projects your commands target.
+- [Output formats & scripting](/datumctl/output-and-scripting) — non-interactive login (`--no-browser`) and service accounts for CI and agents.
+- [Using datumctl with kubectl (kubectl interop)](/datumctl/kubectl-interop) — hand your active session to kubectl with `datumctl auth update-kubeconfig` (existing kubectl users only).

--- a/datumctl/console.mdx
+++ b/datumctl/console.mdx
@@ -1,0 +1,165 @@
+---
+title: "Interactive console"
+sidebarTitle: "Interactive console"
+description: "Browse, inspect, and monitor Datum Cloud resources in a full-screen, keyboard-driven terminal interface."
+---
+
+The interactive console is a full-screen terminal UI for browsing and inspecting your Datum Cloud resources. Instead of running one command at a time, you navigate resource types in a sidebar, scroll through resources in a table, and drill into details, quota, activity, and change history — all without leaving the keyboard.
+
+<Info>
+  Reach for the console when you want to *explore* — to see what exists, check quota headroom, or review recent activity at a glance. Reach for plain commands (`datumctl get`, `datumctl apply`, and friends) when you want to *script*, pipe output to JSON or YAML, or make precise, repeatable changes.
+</Info>
+
+## Launching the console
+
+```bash
+datumctl console
+```
+
+The console opens against your active context (the organization and project resolved from your saved configuration). Use `datumctl ctx` beforehand if you want to start somewhere specific — you can also switch context from inside the console at any time. See [Contexts & scoping](/datumctl/contexts-and-scoping) for how that scope is chosen.
+
+If you are not logged in, the console opens on a welcome screen and walks you through authentication in place (see [Logging in from the console](#logging-in-from-the-console)).
+
+### Read-only mode
+
+```bash
+datumctl console --read-only
+```
+
+The `--read-only` flag disables mutation operations, which makes it safe for demos, screen-sharing, or automated testing where you want to browse without any risk of changing resources.
+
+## The layout
+
+The console is organized into a set of panes. You move between them with a few keys and drill deeper as you go.
+
+<CardGroup cols={2}>
+  <Card title="Navigation sidebar" icon="list">
+    The left column lists the resource types available in your context. Move the cursor with `j`/`k` (or the arrow keys) and press `Enter` to load a type.
+  </Card>
+  <Card title="Resource list" icon="table">
+    The main table shows the resources of the selected type, with a live count in the sidebar. It refreshes automatically in the background.
+  </Card>
+  <Card title="Detail view" icon="magnifying-glass">
+    A full description of a single resource, with toggles for raw YAML, status conditions, and events.
+  </Card>
+  <Card title="Dashboards" icon="gauge">
+    Dedicated quota and activity dashboards summarize allowance usage and recent changes across the project.
+  </Card>
+</CardGroup>
+
+### The welcome panel
+
+When a project context is active, the console opens on a welcome panel that greets you with quick-jump shortcuts, a teaser of recent project activity, and a summary of quota health. From here you can jump straight to a common resource type by pressing a single letter — for example `p` for projects, `w` for workloads, `g` for gateways, `b` for backends, `z` for DNS zones and record sets, or `n` for namespaces. A quick-jump key only fires when a matching resource type exists in your current context.
+
+Press `Esc` from a quick-jumped list to return to the welcome panel in a single step.
+
+## Navigating
+
+Most navigation is the same everywhere: move with `j`/`k` or the arrow keys, go deeper with `Enter`, and step back with `Esc`.
+
+| Key | Action |
+| --- | --- |
+| `j` / `k` (or `↓` / `↑`) | Move the cursor down / up |
+| `Tab` / `Shift+Tab` | Switch focus between the sidebar and the resource list |
+| `Enter` | Select — load a resource type, or open the detail view for the highlighted resource |
+| `Esc` | Step back one level (detail → list → welcome panel) |
+| `/` | Filter the current resource list |
+| `r` | Refresh the current view |
+| `c` | Switch organization / project context |
+| `?` | Toggle the full keybind reference |
+| `q` | Quit (`Ctrl+C` force-quits) |
+
+<Note>
+  Press `?` at any time for the built-in keybind reference. The overlay adapts to where you are, so it shows the actions available in the current pane.
+</Note>
+
+## Inspecting a resource
+
+Select a resource type in the sidebar, press `Enter` to load its list, highlight a row, and press `Enter` (or `d`) to open the detail view. The detail view describes the resource and offers several ways to look at it:
+
+| Key | View |
+| --- | --- |
+| `y` | Toggle raw YAML |
+| `C` | Toggle the status conditions table |
+| `E` | Toggle the events table |
+| `A` | Open the per-resource activity log |
+| `H` | Open the resource's change history |
+
+These views are mutually exclusive toggles — pressing the same key again returns you to the standard description. `Esc` closes the detail view and returns you to the list.
+
+### Change history and diffs
+
+From the detail view, press `H` to open the change history for a resource — a list of past revisions. Highlight a revision and press `Enter` to open a diff. In the diff view, use `[` and `]` to step to the previous or next revision. `Esc` walks back out through the history to the detail view.
+
+## Quota dashboard
+
+The quota dashboard turns allowance buckets into a readable summary of how much of each quota you are consuming.
+
+| Key | Action |
+| --- | --- |
+| `3` | Open the quota dashboard from anywhere (press again to return) |
+| `s` | Toggle grouping of buckets |
+| `t` | Toggle between the dashboard and the raw allowance-bucket table |
+| `r` | Refresh quota data |
+
+The console also surfaces a compact quota banner above the resource list when the type you are viewing has associated allowances, so you see pressure without opening the dashboard. If quota is still loading when you press `3`, the console queues the request and opens the dashboard as soon as the data is ready.
+
+## Activity dashboard
+
+Press `4` to open the activity dashboard — a rollup of recent human activity across the current project. Press `4` again (or `Esc`) to return to where you were, and `r` to refresh the rollup. For querying the same audit logs from the command line, see [Activity](/datumctl/activity).
+
+<Note>
+  The activity dashboard is project-scoped. When your context is an organization without a selected project, the dashboard tells you to select a project first.
+</Note>
+
+## AI assistant
+
+Press `a` from any view to open the built-in AI chat pane, where you can ask questions about your resources in natural language. Type your message and press `Enter` to send; `Tab` switches focus to the conversation history sidebar, and `Ctrl+E` exports the current conversation to a Markdown file. `Esc` returns to the view you came from.
+
+<Note>
+  The assistant needs a model API key configured before it can respond. Configure one with `datumctl ai config` before opening the chat pane — see [Ask datumctl in natural language and connect MCP clients](/datumctl/ai-and-mcp).
+</Note>
+
+## Logging in from the console
+
+If you launch the console without an active session, it opens on a welcome screen. Press `l` to start authentication without leaving the terminal:
+
+<Steps>
+  <Step title="Start the device flow">
+    Press `l`. The console contacts your auth endpoint and displays a verification URL and a one-time code.
+  </Step>
+  <Step title="Authorize in your browser">
+    Open the URL and enter the code, or press `b` to open the URL in your default browser automatically.
+  </Step>
+  <Step title="Pick your context">
+    Once authentication succeeds, the console opens the context picker so you can choose the organization and project to work in, then loads your resources.
+  </Step>
+</Steps>
+
+The console logs in against the same auth endpoint your active session last used, so if you previously authenticated against staging (`auth.staging.env.datum.net`), the in-console flow uses that endpoint too. If a login fails, press `l` to try again or `Esc` to dismiss.
+
+## Console vs. plain commands
+
+<Tabs>
+  <Tab title="Use the console when">
+    - You want to browse what exists and how resources relate.
+    - You are checking quota headroom or reviewing recent activity.
+    - You want to inspect a resource's description, conditions, events, or change history interactively.
+    - You are exploring a new project and prefer a navigable view over remembering exact resource names.
+  </Tab>
+  <Tab title="Use plain commands when">
+    - You are scripting or running in CI, where a non-interactive command is required.
+    - You need machine-readable output to pipe elsewhere (`-o json`, `-o yaml`).
+    - You are making precise, repeatable changes with `datumctl apply`, `create`, or `delete`.
+    - You want to diff a local manifest against the server before writing.
+  </Tab>
+</Tabs>
+
+## Next steps
+
+- [Contexts & scoping](/datumctl/contexts-and-scoping) — set your working organization and project before launching the console.
+- [Authentication](/datumctl/authentication) — learn how authentication and stored credentials work.
+- [Working with resources](/datumctl/working-with-resources) — the read/write commands behind the console's views.
+- [Output formats & scripting](/datumctl/output-and-scripting) — machine-readable output and automation for everything you browse here.
+- [Ask datumctl in natural language and connect MCP clients](/datumctl/ai-and-mcp) — the assistant behind the console's chat pane.
+

--- a/datumctl/contexts-and-scoping.mdx
+++ b/datumctl/contexts-and-scoping.mdx
@@ -1,0 +1,181 @@
+---
+title: "Contexts & scoping"
+sidebarTitle: "Contexts & scoping"
+description: "How datumctl decides which organization or project a command acts on, and how to switch between them."
+---
+
+Almost every `datumctl` command runs against a single **scope** — either one organization or one project inside that organization. Understanding how `datumctl` chooses that scope is the key to getting the results you expect. If a command returns nothing or the wrong resources, the cause is almost always the active scope.
+
+<Info>
+  In short: `datumctl` remembers an **active context** (an org or a project). Any command uses that context unless you override it for a single command with `--organization` or `--project`.
+</Info>
+
+## The scope model
+
+Datum Cloud is organized as a two-level hierarchy:
+
+- **Organizations** are the top level. You belong to one or more organizations.
+- **Projects** live inside an organization. Most day-to-day resources (DNS zones, networking, and so on) belong to a project.
+
+A **context** captures one point in that hierarchy:
+
+- An **org context** points at an organization (for example, resources that live at the organization level).
+- A **project context** points at a specific project inside an organization.
+
+`datumctl` discovers the organizations and projects you can access from the API and stores them locally as a list of contexts. One of them is the **active context** — the scope commands use by default.
+
+## Listing your contexts
+
+Run `datumctl ctx` (alias: `datumctl context`) to see every context available to your active user:
+
+```bash
+datumctl ctx
+```
+
+This prints a table with the display name, the reference you use to select the context, the type (`org` or `project`), and a `*` marking the current active context. Projects are nested under their organization:
+
+```text
+Display Name                    Name                  Type     Current
+Datum Technology, Inc           datum                 org
+  Datum Cloud                   datum/datum-cloud     project  *
+  Staging                       datum/staging         project
+```
+
+The **Name** column is the reference you pass to `datumctl ctx use`: a bare organization ID for an org context (`datum`), or `org/project` for a project context (`datum/datum-cloud`).
+
+<Note>
+  `datumctl ctx list` (alias `datumctl ctx ls`) prints the same table. Running `datumctl ctx` with no subcommand is the shortcut most people use.
+</Note>
+
+### Keeping the list current
+
+The context list is cached locally so listing is instant. When you run `datumctl ctx` and the cache is more than an hour old, `datumctl` refreshes it from the API automatically before printing. To force a refresh at any time — for example, right after you have been granted access to a new project — use the `--refresh` flag:
+
+```bash
+datumctl ctx --refresh
+```
+
+<Note>
+  `--refresh` re-runs discovery using your existing session; it does not require you to log in again. There is no separate `refresh` subcommand — refreshing is a flag on `datumctl ctx`.
+</Note>
+
+## Switching the active context
+
+Use `datumctl ctx use` to change which context is active. You can name the context directly, or run it with no argument to pick from an interactive list:
+
+<Tabs>
+  <Tab title="Interactive picker">
+    ```bash
+    datumctl ctx use
+    ```
+    Choose an organization or project from the list. This is the easiest way when you do not remember the exact name.
+  </Tab>
+  <Tab title="By name">
+    ```bash
+    # Switch to a project context
+    datumctl ctx use datum/datum-cloud
+
+    # Switch to an org context
+    datumctl ctx use datum
+    ```
+  </Tab>
+</Tabs>
+
+You can identify a context by its resource ID (`datum/datum-cloud`) or by its display name (for example, the human-friendly project name shown in the table). Resource IDs always take precedence, and a display name is only accepted when it matches exactly one context. If a name is ambiguous or not found, `datumctl` tells you and suggests running `datumctl ctx` to see the available choices.
+
+On success you'll see a confirmation of the new scope:
+
+```text
+✓ Switched to project Datum Cloud in Datum Technology, Inc (datum/datum-cloud)
+```
+
+The active context persists across commands and terminal sessions until you switch again.
+
+## How scope is resolved for each command
+
+When you run a command, `datumctl` determines its scope by checking these sources **in order** and using the first one that applies:
+
+<Steps>
+  <Step title="Per-command flags">
+    `--organization <org>` or `--project <project>` on the command line. These override everything else, but only for that single command.
+  </Step>
+  <Step title="Environment variables">
+    `DATUM_PROJECT` or `DATUM_ORGANIZATION`, if set. Useful in CI or scripts. You cannot set both at once.
+  </Step>
+  <Step title="The active context">
+    Whatever `datumctl ctx use` last selected. If the active context is a project, commands run at project scope; if it is an org context, they run at organization scope.
+  </Step>
+</Steps>
+
+If none of these provide a scope, `datumctl` falls back to your personal user scope.
+
+<Warning>
+  `--project`, `--organization`, and `--platform-wide` are mutually exclusive — you can supply at most one. Likewise, `DATUM_PROJECT` and `DATUM_ORGANIZATION` cannot both be set. `datumctl` returns an error rather than guessing when the inputs conflict.
+</Warning>
+
+### Overriding scope for a single command
+
+The flags let you target a different org or project without changing your active context:
+
+```bash
+# Run this one command against a different project
+datumctl get dnszones --project other-project
+
+# Run against an organization
+datumctl get projects --organization datum
+```
+
+The next command with no flag goes back to using your active context.
+
+<Note>
+  For advanced access to the platform root rather than a specific project or organization, an opt-in `--platform-wide` flag is also available. Most users never need it.
+</Note>
+
+## When a command returns nothing
+
+An empty result is almost always a scope mismatch, not an error. The resource you're looking for probably lives in a different project or organization than the one your command targeted.
+
+Work through this checklist:
+
+<Steps>
+  <Step title="Confirm the active context">
+    Run `datumctl ctx` and look for the `*`. Make sure it points at the org or project that actually contains your resource.
+  </Step>
+  <Step title="Check for an override you forgot about">
+    An exported `DATUM_PROJECT` or `DATUM_ORGANIZATION` environment variable silently redirects every command. Unset it if it isn't what you want:
+
+    ```bash
+    unset DATUM_PROJECT DATUM_ORGANIZATION
+    ```
+  </Step>
+  <Step title="Target the right scope explicitly">
+    Re-run the command with an explicit flag to rule out the active context:
+
+    ```bash
+    datumctl get dnszones --project my-project
+    ```
+  </Step>
+  <Step title="Refresh if the context is missing">
+    If the project or organization you expect isn't listed by `datumctl ctx`, refresh the cache — you may have just been granted access:
+
+    ```bash
+    datumctl ctx --refresh
+    ```
+  </Step>
+</Steps>
+
+<Info>
+  Remember that a project's resources aren't visible from its parent org context (and vice versa). Switching to the correct project scope with `datumctl ctx use org/project` resolves most "nothing found" surprises.
+</Info>
+
+## Contexts and users
+
+Contexts are tied to the user you're authenticated as. Each stored user session has its own set of discovered contexts. When you switch users, your active context follows that user's most recently used context. For how to log in and switch between accounts, see [Authentication](/datumctl/authentication).
+
+## Related
+
+- [Authentication](/datumctl/authentication) — logging in, switching users, and how sessions map to contexts.
+- [Working with resources](/datumctl/working-with-resources) — the `get`, `apply`, and `delete` commands that run against the scope you set here.
+- [Output formats & scripting](/datumctl/output-and-scripting) — pinning `--organization` and `--project` explicitly and reading `DATUM_PROJECT`/`DATUM_ORGANIZATION` in CI.
+- [Overview](/datumctl/overview) — how `datumctl` is structured and talks to the Datum API.
+- The [CLI Commands reference](/cli/options) for `datumctl ctx` and the `--organization`/`--project` flags.

--- a/datumctl/discovering-resources.mdx
+++ b/datumctl/discovering-resources.mdx
@@ -1,0 +1,170 @@
+---
+title: "Discovering resources & schemas"
+sidebarTitle: "Discovering resources"
+description: "Find which Datum Cloud resource types exist and inspect their fields before you author manifests."
+---
+
+Before you can create or update a resource, you need to know two things: which
+resource types Datum Cloud offers, and what fields each type accepts. `datumctl`
+answers both questions directly from the API server, so what you see always
+reflects the exact version of the platform you are connected to.
+
+Three commands cover discovery:
+
+| Command | Answers |
+|---------|---------|
+| `datumctl api-resources` | Which resource types can I manage? |
+| `datumctl api-versions` | Which API group/version pairs are available? |
+| `datumctl explain <type>` | What fields does this type have, and what do they mean? |
+
+<Info>
+  These commands read from the control plane for your **currently configured
+  context**. Make sure you are logged in (see [Authentication](/datumctl/authentication))
+  and have an organization or project selected first — pass `--organization <org-id>`
+  or `--project <project-id>`, or set a default context. See
+  [Contexts & scoping](/datumctl/contexts-and-scoping) for how that scope is chosen.
+</Info>
+
+## List available resource types
+
+`datumctl api-resources` prints a table of every resource type the current
+control plane supports. It is the starting point for discovering what you can
+manage with `datumctl get`, `datumctl apply`, and `datumctl explain`. The table
+includes each type's short names, API group, whether it is namespaced, and its
+kind.
+
+```bash
+# List all available resource types
+datumctl api-resources
+```
+
+The list is fetched fresh from the server on each run. To reuse a locally
+cached copy, pass `--cached`.
+
+### Narrow and sort the list
+
+For a busy control plane, filter and reshape the output to find what you need:
+
+```bash
+# Show extra detail, including verbs and short names
+datumctl api-resources -o wide
+
+# Sort by name
+datumctl api-resources --sort-by=name
+
+# Only namespaced resource types
+datumctl api-resources --namespaced=true
+
+# Only resource types in a specific API group
+datumctl api-resources --api-group=networking.datumapis.com
+```
+
+<Note>
+  The short names shown here are the same aliases you can use anywhere a
+  resource type is expected — for example in `datumctl get`, `datumctl explain`,
+  or `datumctl describe`.
+</Note>
+
+## List API versions
+
+`datumctl api-versions` prints every API group/version combination the current
+control plane exposes, one per line in the form `group/version` (for example,
+`networking.datumapis.com/v1alpha`).
+
+```bash
+# List all API group/version pairs
+datumctl api-versions
+```
+
+This is the value you place in the `apiVersion` field of a manifest. Use
+`api-versions` when you need the group/version string, and `api-resources` when
+you also want to see the individual resource types within each group.
+
+## Inspect a type's schema
+
+Once you know a type exists, `datumctl explain` shows its schema and field-level
+documentation. Information is retrieved from the API server in OpenAPI format,
+so it always matches the platform version you are connected to.
+
+```bash
+# Show the schema for the Project resource type
+datumctl explain projects
+```
+
+Fields are referenced with dot notation — `TYPE.fieldName.subFieldName` — so you
+can drill into any part of the tree:
+
+```bash
+# Show documentation for just the spec field
+datumctl explain projects.spec
+```
+
+To see the whole schema tree at once instead of one level at a time, use
+`--recursive`:
+
+```bash
+# Expand every field recursively
+datumctl explain projects --recursive
+```
+
+If you prefer the OpenAPI v2 rendering, request it explicitly:
+
+```bash
+# Use the OpenAPI v2 output format
+datumctl explain projects --output=plaintext-openapiv2
+```
+
+## From discovery to a manifest
+
+Discovery feeds directly into authoring manifests for `datumctl apply` and
+`datumctl create`. A typical flow:
+
+<Steps>
+  <Step title="Find the type">
+    Run `datumctl api-resources` to confirm the resource type exists and note
+    its kind and API group.
+
+    ```bash
+    datumctl api-resources --api-group=networking.datumapis.com
+    ```
+  </Step>
+  <Step title="Get the apiVersion">
+    Run `datumctl api-versions` to find the exact `group/version` string for
+    that group.
+
+    ```bash
+    datumctl api-versions
+    ```
+  </Step>
+  <Step title="Learn the fields">
+    Run `datumctl explain <type>` (add `--recursive` for the full tree) to see
+    which fields are required and what they do.
+
+    ```bash
+    datumctl explain projects --recursive
+    ```
+  </Step>
+  <Step title="Write and validate the manifest">
+    Author your YAML with the `apiVersion`, `kind`, and `spec` fields you
+    discovered, then validate it against the server before persisting.
+
+    ```bash
+    datumctl apply -f ./project.yaml --organization <org-id> --dry-run=server
+    ```
+  </Step>
+</Steps>
+
+<Tip>
+  `datumctl explain <type>.spec` is the fastest way to see exactly which fields
+  belong under `spec` when you are filling out a new manifest.
+</Tip>
+
+## Related
+
+- [Working with resources](/datumctl/working-with-resources) — author, apply, and edit
+  resources once you know which types exist and what fields they take.
+- [Output formats & scripting](/datumctl/output-and-scripting) — render this discovery
+  output as JSON or YAML and pipe it into other tooling.
+- [Authentication](/datumctl/authentication) — sign in before querying the control plane.
+- The [CLI Commands reference](/cli/options) for `api-resources`, `api-versions`, and
+  `explain`.

--- a/datumctl/kubectl-interop.mdx
+++ b/datumctl/kubectl-interop.mdx
@@ -1,0 +1,175 @@
+---
+title: "Using datumctl with kubectl"
+sidebarTitle: "kubectl interop"
+description: "Point kubectl at a Datum Cloud control plane using your active datumctl session — an opt-in escape hatch for existing kubectl users."
+---
+
+<Warning>
+  This guide is for **kubectl users only**. Datum Cloud requires no Kubernetes
+  knowledge — you manage organizations, projects, DNS zones, and other
+  resources directly with `datumctl get`, `datumctl apply`, `datumctl delete`,
+  and friends. If you have never used kubectl, you can skip this page entirely.
+</Warning>
+
+Some teams already run kubectl and want to reuse it against Datum Cloud. The
+commands on this page are an **opt-in escape hatch**, not the primary path.
+Everything you can do here you can also do with native `datumctl` commands, and
+we recommend the native commands for day-to-day work. If you do use kubectl,
+`datumctl` acts as the credential source so you never manage static keys.
+
+<Info>
+  Before you start, log in with the primary command so `datumctl` has an active
+  session to hand to kubectl:
+
+  ```text
+  datumctl login
+  ```
+
+  For CI or headless environments, add `--no-browser`. For staging, add
+  `--hostname auth.staging.env.datum.net`.
+</Info>
+
+## Generate a kubeconfig entry
+
+`datumctl auth update-kubeconfig` adds or updates a cluster, user, and context
+entry in your kubeconfig so kubectl can authenticate to a Datum Cloud control
+plane using your active `datumctl` session. After it runs, kubectl
+automatically calls `datumctl auth get-token` to obtain a fresh credential on
+each request — there is nothing to rotate by hand.
+
+You must specify exactly **one** of `--organization` or `--project`. The two
+flags are mutually exclusive.
+
+<Tabs>
+  <Tab title="Organization control plane">
+    ```bash
+    datumctl auth update-kubeconfig --organization my-org-id
+    ```
+  </Tab>
+  <Tab title="Project control plane">
+    ```bash
+    datumctl auth update-kubeconfig --project my-project-id
+    ```
+  </Tab>
+</Tabs>
+
+On success, `datumctl` prints the kubeconfig path it wrote to, the user it
+configured, and the API server it targeted. It also sets the new entry as your
+current context.
+
+### Flags
+
+| Flag | Description |
+| --- | --- |
+| `--organization <id>` | Configure access to an organization's control plane. Mutually exclusive with `--project`. |
+| `--project <id>` | Configure access to a specific project's control plane. Mutually exclusive with `--organization`. |
+| `--kubeconfig <path>` | Path to the kubeconfig file to update. |
+| `--hostname <host>` | Override the API server hostname. Useful for self-hosted environments where the hostname cannot be derived from stored credentials. |
+| `--exec-interactive-mode <mode>` | Interactive mode for the kubeconfig exec credential plugin. One of `Never`, `IfAvailable` (default), or `Always`. |
+
+### Choosing where the kubeconfig is written
+
+By default, `datumctl` updates `$HOME/.kube/config`. If the `KUBECONFIG`
+environment variable is set, that path is used instead. Pass `--kubeconfig` to
+write to an explicit file — handy for keeping Datum Cloud entries separate from
+your other clusters.
+
+```bash
+datumctl auth update-kubeconfig --organization my-org-id --kubeconfig ~/.kube/datum-config
+```
+
+### Non-interactive use in CI and scripts
+
+The generated kubeconfig entry runs `datumctl` as a credential plugin. In an
+interactive shell it can prompt you (for example, to complete a login) when a
+credential is needed. In CI or other non-interactive contexts, set the exec
+plugin's interactive mode to `Never` so kubectl fails fast instead of waiting
+on a prompt that can never be answered.
+
+```bash
+datumctl auth update-kubeconfig --project my-project-id --exec-interactive-mode Never
+```
+
+<Note>
+  The default is `IfAvailable`, which uses interactive prompts only when a
+  terminal is attached. `Always` requires an interactive terminal. Use `Never`
+  for automation.
+</Note>
+
+## Confirm your identity
+
+Once a control plane context is configured, `datumctl auth whoami` queries the
+Datum Cloud API server and shows the user identity and group memberships it
+resolved from your current credentials. It is useful for confirming which
+account kubectl is using and for troubleshooting access-denied errors.
+
+```bash
+datumctl auth whoami
+
+# Show the resolved identity as JSON
+datumctl auth whoami -o json
+```
+
+<Note>
+  `datumctl auth whoami` requires a control plane context configured with
+  `datumctl auth update-kubeconfig`. To see which `datumctl` account is
+  currently active without any control plane context, use `datumctl auth list`
+  instead.
+</Note>
+
+## Check permissions
+
+`datumctl auth can-i` verifies whether the active user is allowed to perform a
+specific action against a Datum Cloud resource type on the configured control
+plane. Provide an API verb (`get`, `list`, `watch`, `create`, `update`,
+`patch`, `delete`, or `*`) and a resource type.
+
+```bash
+# Check if you can list projects on the control plane
+datumctl auth can-i list projects
+
+# Check if you can create DNS zones
+datumctl auth can-i create dnszones
+
+# List all your permitted actions
+datumctl auth can-i --list
+
+# List permitted actions in a specific namespace
+datumctl auth can-i --list --namespace default
+```
+
+<Tip>
+  Run `datumctl api-resources` to see the resource types you can name in a
+  `can-i` check — [Discovering resources & schemas](/datumctl/discovering-resources)
+  covers resource discovery in full.
+</Tip>
+
+## How the credential handoff works
+
+<Steps>
+  <Step title="You configure the entry">
+    `datumctl auth update-kubeconfig` writes a context whose user runs
+    `datumctl auth get-token` as an exec credential plugin.
+  </Step>
+  <Step title="kubectl requests a token">
+    On each request, kubectl invokes `datumctl auth get-token`, which returns a
+    short-lived credential for the API server.
+  </Step>
+  <Step title="datumctl refreshes automatically">
+    If the stored token has expired, `datumctl` uses your refresh token to get
+    a new one before returning it — no static keys, no manual rotation.
+  </Step>
+</Steps>
+
+Because the kubeconfig entry pins to the `datumctl` session that was active
+when you generated it, switching accounts with `datumctl auth switch` and
+regenerating the entry keeps kubectl aligned with the account you intend to use.
+
+## Related
+
+- [Authentication](/datumctl/authentication) — the native, no-Kubernetes-required
+  workflow for signing in, switching users, and managing sessions.
+- [Working with resources](/datumctl/working-with-resources) — the native `get`,
+  `apply`, and `delete` commands that replace kubectl for day-to-day work.
+- [Output formats & scripting](/datumctl/output-and-scripting) — retrieving tokens
+  and machine-readable output for scripting and credential-helper use.

--- a/datumctl/output-and-scripting.mdx
+++ b/datumctl/output-and-scripting.mdx
@@ -1,0 +1,217 @@
+---
+title: "Output formats & scripting"
+sidebarTitle: "Output & scripting"
+description: "Machine-readable output, structured errors, exit codes, and patterns for wrapping datumctl in CI pipelines and AI agents."
+---
+
+`datumctl` prints human-friendly tables by default, but it is built to be scripted. Every read command can emit JSON or YAML, errors can be serialized into a structured envelope, and exit codes are predictable. This page shows you how to drive `datumctl` from shell scripts, CI pipelines, and AI agents.
+
+<Info>
+  `datumctl` writes command results to **stdout** and errors to **stderr**. These are two independent channels controlled by two independent flags: `-o`/`--output` shapes the data on stdout, and `--error-format` shapes errors on stderr. You can set them independently.
+</Info>
+
+## Choosing an output format
+
+Read and inspection commands accept the `-o` (or `--output`) flag. When you omit it, `datumctl` prints a formatted table designed for humans. Pass a machine format to get output you can parse.
+
+The `-o` flag is **per-command** — it is not a global flag. It is available on commands that render resources, including `datumctl get`, `datumctl edit`, `datumctl create`, `datumctl apply`, `datumctl version`, and `datumctl api-resources`.
+
+For `datumctl get`, the supported values are:
+
+| Value | Description |
+| --- | --- |
+| _(none)_ | Formatted table (the default), for reading in a terminal. |
+| `wide` | The default table plus extra columns. |
+| `json` | A single JSON document. Best for piping into `jq`. |
+| `yaml` | A YAML document. |
+| `name` | Just the resource identifiers, one per line — ideal for shell loops. |
+| `jsonpath`, `jsonpath-as-json`, `jsonpath-file` | Extract specific fields with a JSONPath expression. |
+| `custom-columns`, `custom-columns-file` | Build your own column layout. |
+| `go-template`, `go-template-file`, `template`, `templatefile` | Render output through a Go template. |
+
+<Note>
+  A few commands take `-o` but with their own value set. `datumctl explain` accepts `-o plaintext` or `-o plaintext-openapiv2` to choose a schema-rendering style, and `datumctl diff` always emits YAML (it has no `-o` flag). When in doubt, run `datumctl <command> --help`.
+</Note>
+
+```bash
+# Default table — human reading
+datumctl get projects --organization <org-id>
+
+# Full resource as JSON
+datumctl get project my-project-id --organization <org-id> -o json
+
+# Full resource as YAML
+datumctl get project my-project-id --organization <org-id> -o yaml
+
+# Just the names, one per line
+datumctl get projects --organization <org-id> -o name
+```
+
+## Piping and jq patterns
+
+Because `-o json` produces standard JSON, you can pipe it straight into [`jq`](https://jqlang.github.io/jq/) or any JSON tooling.
+
+```bash
+# Pull a single field out of one resource
+datumctl get project my-project-id --organization <org-id> -o json \
+  | jq -r '.metadata.name'
+
+# List returns a JSON object with an "items" array — iterate it
+datumctl get projects --organization <org-id> -o json \
+  | jq -r '.items[].metadata.name'
+
+# Filter by a status condition
+datumctl get projects --organization <org-id> -o json \
+  | jq -r '.items[] | select(.status.conditions[]?.type == "Ready") | .metadata.name'
+```
+
+The `name` format is the simplest way to feed identifiers into a loop:
+
+```bash
+# Describe every project in an organization
+datumctl get projects --organization <org-id> -o name \
+  | while read -r ref; do
+      datumctl describe "$ref" --organization <org-id>
+    done
+```
+
+<Tip>
+  For extracting one or two fields you often do not need `jq` at all — a `jsonpath` expression keeps the whole thing in one process:
+
+  ```bash
+  datumctl get projects --organization <org-id> \
+    -o jsonpath='{.items[*].metadata.name}'
+  ```
+</Tip>
+
+## Structured errors
+
+By default `datumctl` prints errors as plain text on stderr, prefixed with `error:`. For automation you can switch to a structured envelope with the global `--error-format` flag.
+
+`--error-format` is a **persistent (global) flag** — it works on every command. It accepts one of three values:
+
+| Value | Behavior |
+| --- | --- |
+| `human` | The default. Human-readable `error: <message>` text on stderr. |
+| `json` | A single-line JSON error envelope. |
+| `yaml` | The same envelope rendered as YAML. |
+
+Passing any other value fails fast before the command runs:
+
+```text
+$ datumctl get organizations --error-format foo
+error: invalid value "foo" for --error-format
+Allowed values: human, json, yaml.
+```
+
+In `json` or `yaml` mode, a failed command emits an envelope under a top-level `error` key:
+
+```bash
+datumctl get projects --organization does-not-exist --error-format json
+```
+
+```json
+{
+  "error": {
+    "message": "the organization \"does-not-exist\" was not found",
+    "hint": "Run 'datumctl get organizations' to see organizations you can access.",
+    "retryable": false
+  }
+}
+```
+
+The `code`, `hint`, and `details` fields are omitted when they are empty, so the exact set of keys varies by error. The envelope fields are:
+
+| Field | Meaning |
+| --- | --- |
+| `message` | The user-facing error message. Always present. |
+| `code` | An optional machine-readable identifier (for example `AUTH_EXPIRED`) that agents can branch on. Omitted when empty. |
+| `hint` | Actionable guidance for resolving the error, when available. Omitted when empty. |
+| `retryable` | `true` when the operation can be safely retried without further action. Always present. |
+| `details` | The underlying technical error, when one is attached. Omitted when empty. |
+
+<Note>
+  `--error-format` only changes how **errors** are serialized on stderr. It does not affect successful command output on stdout — that is controlled entirely by `-o`. A script can safely combine, for example, `-o json` for results and `--error-format json` for failures.
+</Note>
+
+## Treating warnings as errors
+
+`--warnings-as-errors` is a global boolean flag (hidden from `--help` output) that causes server-side warnings returned by resource commands to be treated as failures, producing a non-zero exit. Use it in pipelines when you want deprecation notices or other API warnings to break the build rather than pass silently.
+
+```bash
+datumctl apply -f ./project.yaml --organization <org-id> --warnings-as-errors
+```
+
+## Exit codes
+
+`datumctl` follows conventional exit-code semantics, so scripts can branch on `$?`:
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | Success. |
+| `1` | A general error — for example an unknown command, an invalid flag value, an authentication failure, or an API request that failed. |
+| `>1` | A lower-level fatal error surfaced by the underlying request machinery. |
+
+`datumctl diff` is a special case, mirroring the `diff` convention:
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | No differences were found. |
+| `1` | Differences were found. |
+| `>1` | An error occurred. |
+
+This makes `diff` useful as a gate before writing:
+
+```bash
+datumctl diff -f ./project.yaml --organization <org-id> \
+  && datumctl apply -f ./project.yaml --organization <org-id>
+```
+
+## Wrapping datumctl in scripts and agents
+
+<Steps>
+  <Step title="Authenticate non-interactively">
+    Interactive browser login is the default. For CI and headless environments, pass `--no-browser` to `datumctl login`, or use a service account. Never rely on a prompt that a pipeline cannot answer. See [Authentication](/datumctl/authentication) for the login and session details.
+  </Step>
+  <Step title="Always pass a machine format">
+    Add `-o json` (or `-o yaml`) to read commands and `--error-format json` globally. Do not parse the human table — its columns are meant to change over time.
+  </Step>
+  <Step title="Pin the context explicitly">
+    Pass `--organization` and `--project` on every invocation instead of relying on the active context. Scripts and agents should be self-describing and not depend on ambient state that another process might change. See [Contexts & scoping](/datumctl/contexts-and-scoping) for how scope is resolved and which flags and environment variables win.
+  </Step>
+  <Step title="Branch on exit codes and the error envelope">
+    Check `$?` first. When it is non-zero and you asked for `--error-format json`, parse the `error` envelope: read `retryable` to decide whether to back off and retry, and `code`/`hint` to decide what to do next.
+  </Step>
+  <Step title="Prefer safe, idempotent operations">
+    Use `datumctl apply` for declarative create-or-update, validate with `--dry-run=server`, and preview writes with `datumctl diff -f`. Remember that `datumctl delete` proceeds without a confirmation prompt.
+  </Step>
+</Steps>
+
+<Warning>
+  `datumctl delete` has no confirmation prompt. In automation, gate destructive operations behind an explicit review step or a `--dry-run=client` preview before running the real delete.
+</Warning>
+
+A minimal, robust wrapper looks like this:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ORG="my-org-id"
+
+if ! output=$(datumctl get projects --organization "$ORG" -o json --error-format json 2>err.json); then
+  code=$(jq -r '.error.code // empty' err.json)
+  retryable=$(jq -r '.error.retryable' err.json)
+  echo "datumctl failed (code=${code:-none}, retryable=$retryable)" >&2
+  exit 1
+fi
+
+echo "$output" | jq -r '.items[].metadata.name'
+```
+
+## Related
+
+- [Authentication](/datumctl/authentication) — how to log in interactively and non-interactively, including `--no-browser` for CI and headless flows.
+- [Contexts & scoping](/datumctl/contexts-and-scoping) — how the active organization and project are resolved, and how to set them explicitly.
+- [Working with resources](/datumctl/working-with-resources) — the `get`, `apply`, `diff`, and `delete` commands these output and error controls apply to.
+- [Discovering resources & schemas](/datumctl/discovering-resources) — the `api-resources`, `api-versions`, and `explain` commands that also honor `-o` for machine-readable output.

--- a/datumctl/overview.mdx
+++ b/datumctl/overview.mdx
@@ -4,10 +4,10 @@ sidebarTitle: "Overview"
 description: "High level overview of the Datum Cloud CLI."
 ---
 
-`datumctl` is the command-line tool for working with Datum Cloud. If you’ve used kubectl, you'll find a similar model with resources, commands, and a predictable structure. For both developers and AI agents, `datumctl` is the fastest way to interact with Datum.
+`datumctl` is the command-line tool for working with Datum Cloud. It exposes a consistent resource model — the same `get`, `apply`, `describe`, and `delete` verbs across every resource type — so both developers and AI agents get a fast, predictable way to interact with Datum.
 
 <Info>
-  Ready to play? Download and install via [our downloads page](https://www.datum.net/download/datumctl/).
+  Ready to play? Download and install via [our downloads page](https://www.datum.net/download/datumctl/), or follow the [Quickstart](/datumctl/quickstart) to go from install to your first command in a few minutes.
 </Info>
 
 ## How these docs are organized
@@ -16,6 +16,14 @@ description: "High level overview of the Datum Cloud CLI."
 
 - **datumctl** (this section) covers concepts, authentication, and workflows — start here to learn how the CLI works.
 - **[CLI Commands](/cli/options)** contains the full flag-level reference for each command (`datumctl apply`, `datumctl get`, and so on).
+
+Within this section, the guides build on each other:
+
+- **Getting started** — new to the CLI? The [Quickstart](/datumctl/quickstart) walks you through installing, logging in, picking a context, and running your first command.
+- **Core concepts** — [Contexts & scoping](/datumctl/contexts-and-scoping) explains how a command decides which organization or project it acts on; [Working with resources](/datumctl/working-with-resources) covers the create/read/update/delete workflow; [Discovering resources & schemas](/datumctl/discovering-resources) shows how to find resource types and inspect their fields; and [Output formats & scripting](/datumctl/output-and-scripting) covers machine-readable output, structured errors, and wrapping the CLI in automation.
+- **Interactive & AI** — the [Interactive console](/datumctl/console) is a full-screen terminal UI for browsing resources, and the AI assistant lets you [ask datumctl in natural language and connect MCP clients](/datumctl/ai-and-mcp).
+- **Plugins** — extend the CLI with additional commands. Start with [Using plugins](/datumctl/plugins/using-plugins).
+- **Reference & interop** — [Authentication](/datumctl/authentication), [using datumctl with kubectl (kubectl interop)](/datumctl/kubectl-interop), and the [Activity](/datumctl/activity) audit-log commands.
 
 ## Design goals
 

--- a/datumctl/plugins/building-plugins.mdx
+++ b/datumctl/plugins/building-plugins.mdx
@@ -135,7 +135,7 @@ func main() {
 
 ### The injected context
 
-`plugin.Context()` returns the values datumctl sets before running your plugin:
+`plugin.Context()` returns the values datumctl sets before running your plugin — these come from the user's [active context](/datumctl/contexts-and-scoping):
 
 | Field | Environment variable | Description |
 |-------|----------------------|-------------|

--- a/datumctl/plugins/using-plugins.mdx
+++ b/datumctl/plugins/using-plugins.mdx
@@ -18,7 +18,7 @@ When you install the `compute` plugin from the official **datum** catalog, its c
 datumctl compute --help
 ```
 
-datumctl injects your current organization, project, and a fresh short-lived access token into the plugin automatically, so plugins work with your active context and credentials without a separate login.
+datumctl injects your current organization, project, and a fresh short-lived access token into the plugin automatically, so plugins work with your [active context](/datumctl/contexts-and-scoping) and [credentials](/datumctl/authentication) without a separate login.
 
 Plugins come from **catalogs** (also called indexes). The official **datum** catalog is curated by Datum and always available with no setup — its plugins carry an `official` trust badge. You can also add third-party catalogs, whose plugins carry a `third-party` badge. See [Adding catalogs](/datumctl/plugins/adding-catalogs) to register more.
 
@@ -169,3 +169,5 @@ Trusting records the binary's path and fingerprint. If the binary changes afterw
 
 - [Adding catalogs](/datumctl/plugins/adding-catalogs) — register additional or internal marketplaces
 - [Building plugins](/datumctl/plugins/building-plugins) — write your own plugin with the Go SDK
+- [Quickstart](/datumctl/quickstart) — new to `datumctl`? Install and log in first
+- [Contexts & scoping](/datumctl/contexts-and-scoping) — the organization and project a plugin inherits when it runs

--- a/datumctl/quickstart.mdx
+++ b/datumctl/quickstart.mdx
@@ -1,0 +1,141 @@
+---
+title: "Quickstart"
+sidebarTitle: "Quickstart"
+description: "Install datumctl, log in, pick a context, and run your first command."
+---
+
+This guide takes you from nothing installed to running your first command against Datum Cloud. Follow the steps in order — the whole path takes just a few minutes.
+
+<Info>
+  Prefer a one-click download? Grab a build from [our downloads page](https://www.datum.net/download/datumctl/).
+</Info>
+
+<Steps>
+  <Step title="Install datumctl">
+    Choose the method that fits your platform.
+
+    <Tabs>
+      <Tab title="Homebrew (macOS)">
+        If you use [Homebrew](https://brew.sh/), install `datumctl` from the official Datum Cloud tap:
+
+        ```bash
+        # Tap the Datum Cloud formula repository (only needs to be done once)
+        brew tap datum-cloud/homebrew-tap
+
+        # Trust the datumctl formula
+        brew trust --formula datum-cloud/homebrew-tap/datumctl
+
+        # Install datumctl
+        brew install datumctl
+        ```
+
+        Later, upgrade with `brew upgrade datumctl`.
+      </Tab>
+      <Tab title="Direct download">
+        Download a pre-built binary from the [GitHub Releases page](https://github.com/datum-cloud/datumctl/releases/latest):
+
+        1. Find the archive for your OS and architecture (for example `datumctl_Darwin_arm64.tar.gz`, `datumctl_Linux_x86_64.tar.gz`, or `datumctl_Windows_amd64.zip`).
+        2. Download and extract it.
+        3. Move the `datumctl` (or `datumctl.exe`) binary onto your `PATH` — for example `/usr/local/bin` on Linux/macOS.
+        4. On Linux/macOS, make sure it is executable: `chmod +x /path/to/datumctl`.
+      </Tab>
+    </Tabs>
+
+    Verify the install:
+
+    ```bash
+    datumctl version
+    ```
+
+    This prints the installed client version.
+  </Step>
+
+  <Step title="Log in">
+    Authenticate with Datum Cloud. `datumctl` uses OAuth 2.0 with PKCE and stores your credentials securely in your system keyring — there are no API keys to manage.
+
+    ```bash
+    datumctl login
+    ```
+
+    This opens your browser to complete sign-in, then discovers the organizations and projects you can access. For managing multiple accounts, switching users, and signing out, see [Authentication](/datumctl/authentication).
+
+    <Note>
+      On a headless machine — SSH session, CI runner, or container with no browser — add `--no-browser` to authenticate with a device-code flow instead:
+
+      ```bash
+      datumctl login --no-browser
+      ```
+
+      To sign in against a non-production environment, point at its auth server with `--hostname`, for example `datumctl login --hostname auth.staging.env.datum.net`.
+    </Note>
+  </Step>
+
+  <Step title="Select your working context">
+    A context is the organization or project that commands target by default, so you do not have to pass `--organization` or `--project` every time. For the full picture of how scope is resolved, read [Contexts & scoping](/datumctl/contexts-and-scoping).
+
+    Right after login, `datumctl` shows the organizations and projects you can access and prompts you to pick one interactively.
+
+    To see your contexts again at any time:
+
+    ```bash
+    datumctl ctx
+    ```
+
+    To switch contexts — either interactively or by name using the `org` or `org/project` format:
+
+    ```bash
+    # Interactive picker
+    datumctl ctx use
+
+    # Switch to a specific project context
+    datumctl ctx use <org-id>/<project-id>
+    ```
+  </Step>
+
+  <Step title="Run your first command">
+    List the organizations you belong to. This command works without a context selected:
+
+    ```bash
+    datumctl get organizations
+    ```
+
+    Once a context is set, list resources in it — for example the projects in your organization:
+
+    ```bash
+    datumctl get projects --organization <org-id>
+    ```
+
+    Results are shown as a table by default. Add `-o json` or `-o yaml` for scripting or inspection (see [Output formats & scripting](/datumctl/output-and-scripting)), and use `datumctl api-resources` to [discover every resource type you can manage](/datumctl/discovering-resources).
+  </Step>
+</Steps>
+
+## Next steps
+
+You are now installed, authenticated, and pointed at a context. From here you can explore what else the CLI can do.
+
+<CardGroup cols={2}>
+  <Card title="Contexts & scoping" icon="crosshairs" href="/datumctl/contexts-and-scoping">
+    Understand how commands choose an organization or project, and how to switch between them.
+  </Card>
+  <Card title="Working with resources" icon="cubes" href="/datumctl/working-with-resources">
+    Create, inspect, update, and delete Datum Cloud resources.
+  </Card>
+  <Card title="Discovering resources & schemas" icon="magnifying-glass" href="/datumctl/discovering-resources">
+    Find which resource types exist and inspect their fields before you author manifests.
+  </Card>
+  <Card title="Output formats & scripting" icon="terminal" href="/datumctl/output-and-scripting">
+    Machine-readable output, structured errors, and wrapping datumctl in CI and agents.
+  </Card>
+  <Card title="Interactive console" icon="table-columns" href="/datumctl/console">
+    Browse and inspect resources in a full-screen, keyboard-driven UI.
+  </Card>
+  <Card title="Using plugins" icon="puzzle-piece" href="/datumctl/plugins/using-plugins">
+    Extend datumctl with additional commands from a plugin catalog.
+  </Card>
+  <Card title="Authentication" icon="key" href="/datumctl/authentication">
+    Manage multiple accounts, switch users, and sign out.
+  </Card>
+  <Card title="Overview" icon="compass" href="/datumctl/overview">
+    Understand how datumctl is structured and how it talks to Datum Cloud.
+  </Card>
+</CardGroup>

--- a/datumctl/working-with-resources.mdx
+++ b/datumctl/working-with-resources.mdx
@@ -3,7 +3,11 @@ title: "Working with Resources"
 description: "Core patterns for creating, inspecting, and managing Datum resources using datumctl."
 ---
 
-`datumctl` follows the same resource model as `kubectl`. If you are familiar with Kubernetes, these patterns will feel immediately familiar. If not, a small set of commands covers most day-to-day work.
+`datumctl` uses a single, consistent resource model: the same handful of verbs — `get`, `apply`, `describe`, `delete` — work across every Datum Cloud resource type. Learn them once and you can manage anything the platform exposes, with no Kubernetes knowledge required.
+
+<Info>
+  New to the CLI? Start with the [Quickstart](/datumctl/quickstart) to install, log in, and run your first command. Every command here runs against your active scope — see [Contexts & scoping](/datumctl/contexts-and-scoping) to control which organization or project that is.
+</Info>
 
 ---
 
@@ -14,9 +18,12 @@ description: "Core patterns for creating, inspecting, and managing Datum resourc
 | `datumctl get <resource>` | List resources |
 | `datumctl get <resource> <name> -o yaml` | View a full resource definition |
 | `datumctl explain <resource>` | Inspect the API schema for a resource type |
-| `datumctl explain <resource> --recursive` | View the full schema tree |
 | `datumctl apply -f <file>` | Create or update a resource from a file or stdin |
 | `datumctl delete <resource> <name>` | Delete a resource |
+
+<Note>
+  Not sure which resource types exist or what fields they take? [Discovering resources & schemas](/datumctl/discovering-resources) covers `api-resources`, `api-versions`, and `explain` in depth.
+</Note>
 
 ---
 
@@ -35,9 +42,9 @@ description: "Core patterns for creating, inspecting, and managing Datum resourc
 
 Datum resources are defined declaratively. This means you can:
 
-- Inspect the API structure directly from the platform using `datumctl explain`
+- Inspect the API structure directly from the platform using `datumctl explain` (see [Discovering resources & schemas](/datumctl/discovering-resources))
 - Store resource definitions in version control
-- Automate deployments via CI/CD pipelines
+- Automate deployments via CI/CD pipelines (see [Output formats & scripting](/datumctl/output-and-scripting))
 - Treat network configuration as code
 
 A typical workflow looks like this:
@@ -46,6 +53,9 @@ A typical workflow looks like this:
 # Inspect the schema
 datumctl explain httpproxy --recursive
 
+# Preview the change before writing
+datumctl diff --project my-project --namespace default -f proxy.yaml
+
 # Apply a configuration
 datumctl apply --project my-project --namespace default -f proxy.yaml
 
@@ -53,25 +63,29 @@ datumctl apply --project my-project --namespace default -f proxy.yaml
 datumctl get httpproxy my-proxy --namespace default -o yaml
 ```
 
+<Tip>
+  Prefer `datumctl diff -f` and `--dry-run=server` before writes, and remember that `datumctl delete` has no confirmation prompt. [Output formats & scripting](/datumctl/output-and-scripting) covers safe patterns for automation.
+</Tip>
+
 ---
 
 ## Namespaces
 
-All resources are created in a namespace. Current examples use the `default` namespace:
+Many project-scoped resources live in a namespace. The examples above use the `default` namespace:
 
 ```bash
 --namespace default
 ```
 
-If your CLI defaults to `default`, you may omit it from commands. To check your current context:
-
-```bash
-datumctl config view
-```
+If a command targets the `default` namespace, you may omit the flag. Which organization or project a command runs against — and how to switch — is covered in [Contexts & scoping](/datumctl/contexts-and-scoping); run `datumctl ctx` to see your active context.
 
 ---
 
 ## Next Steps
 
-- [Authentication](/datumctl/authentication) — Log in and manage credentials
-- [CLI Reference](/cli/options) — Full flag-level reference for every command
+- [Discovering resources & schemas](/datumctl/discovering-resources) — find resource types and inspect their fields before authoring manifests
+- [Contexts & scoping](/datumctl/contexts-and-scoping) — control which organization or project commands act on
+- [Output formats & scripting](/datumctl/output-and-scripting) — machine-readable output, structured errors, and CI patterns
+- [Interactive console](/datumctl/console) — browse and inspect the same resources in a full-screen UI
+- [Authentication](/datumctl/authentication) — log in and manage credentials
+- [CLI Commands](/cli/options) — full flag-level reference for every command

--- a/docs.json
+++ b/docs.json
@@ -141,10 +141,30 @@
       {
         "tab": "datumctl (CLI)",
         "icon": "terminal",
-        "pages": [
-          "datumctl/overview",
-          "datumctl/authentication",
-          "datumctl/activity",
+        "groups": [
+          {
+            "group": "Getting started",
+            "pages": [
+              "datumctl/overview",
+              "datumctl/quickstart"
+            ]
+          },
+          {
+            "group": "Core concepts",
+            "pages": [
+              "datumctl/contexts-and-scoping",
+              "datumctl/working-with-resources",
+              "datumctl/discovering-resources",
+              "datumctl/output-and-scripting"
+            ]
+          },
+          {
+            "group": "Interactive & AI",
+            "pages": [
+              "datumctl/console",
+              "datumctl/ai-and-mcp"
+            ]
+          },
           {
             "group": "Plugins",
             "pages": [
@@ -152,6 +172,14 @@
               "datumctl/plugins/adding-catalogs",
               "datumctl/plugins/publishing-catalogs",
               "datumctl/plugins/building-plugins"
+            ]
+          },
+          {
+            "group": "Reference & interop",
+            "pages": [
+              "datumctl/authentication",
+              "datumctl/kubectl-interop",
+              "datumctl/activity"
             ]
           }
         ]


### PR DESCRIPTION
Expands the **datumctl (CLI)** documentation section from a thin set of pages into a coherent, well-linked guide, and makes information flow between every doc with descriptive link text.

## New guides
- **Quickstart** — install → log in → set context → first command.
- **Contexts & scoping** — the organization/project model, `datumctl ctx`, and the `--organization`/`--project` flags (the #1 source of "why do I see nothing?" confusion).
- **Output formats & scripting** — `-o` formats, structured `--error-format`, and automation/agent patterns.
- **Discovering resources & schemas** — `api-resources`, `api-versions`, and `explain`.
- **Interactive console** — `datumctl console` panes, navigation, dashboards, and in-console login.
- **AI assistant & MCP** — `datumctl ai` and the `datumctl mcp` server (cross-linked with the Agents-tab MCP page).
- **Using datumctl with kubectl** — opt-in `auth update-kubeconfig`/`whoami`/`can-i` for kubectl users only.

## Section-wide weave
- Restructured the CLI tab into groups: **Getting started · Core concepts · Interactive & AI · Plugins · Reference & interop**.
- **Un-orphaned** `working-with-resources` and `console` (both were missing from the nav) and de-duplicated overlapping content down to single canonical homes.
- Added descriptive cross-links (no bare URLs or "click here") throughout the new *and* existing docs so readers move naturally between related tasks.

Every command, flag, and keybinding was verified against the datumctl source. `docs.json` validated.

> Stacked on `docs/datumctl-plugins` (PR #37) so the plugin cross-links resolve — retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)