### PR TITLE
Pilot: API resources reference tab (DNS + Networking)

### DIFF
--- a/api/dns/dnsrecordset.mdx
+++ b/api/dns/dnsrecordset.mdx
@@ -1,0 +1,98 @@
+---
+title: "DNSRecordSet"
+sidebarTitle: "DNSRecordSet"
+description: "DNSRecordSet is the Schema for the dnsrecordsets API."
+---
+
+<Note>
+  API resource reference for **DNSRecordSet**, part of the [DNS service](/api/dns/overview). To create or change one, see [Changing resources](/datumctl/resources/changing); to read or inspect, see [Reading resources](/datumctl/resources/reading). For the underlying concept, see [Domains & DNS](/domain-dns/dns).
+</Note>
+
+<Warning>
+  This resource is part of an **alpha** API (`v1alpha1`). Fields and behavior are subject to change without notice.
+</Warning>
+
+## Identity
+
+| | |
+| --- | --- |
+| Group | `dns.networking.miloapis.com` |
+| Version | `v1alpha1` |
+| Kind | `DNSRecordSet` |
+| Scope | Project |
+
+## Overview
+
+A `DNSRecordSet` defines a set of DNS resource records of a single type (for example, `A`, `AAAA`, `CNAME`, or `TXT`) within a DNS zone. Each recordset references the `DNSZone` it belongs to and carries one or more owner names, each with values appropriate for the record type. Use it to publish and manage the DNS records that resolve names in a zone you own.
+
+## Spec fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `spec.dnsZoneRef` | Object | Yes | DNSZoneRef references the DNSZone this recordset belongs to. |
+| `spec.dnsZoneRef.name` | string | No | Name of the referent DNSZone. |
+| `spec.recordType` | string | Yes | The DNS RR type for this recordset. One of the enum values `A`, `AAAA`, `ALIAS`, `CNAME`, and others. |
+| `spec.records` | []Object | Yes | One or more owner names with values appropriate for the RecordType. |
+| `spec.records[].name` | string | Yes | The owner name (relative to the zone or FQDN). |
+| `spec.records[].ttl` | integer | No | Optionally overrides the TTL for this owner/RRset. |
+| `spec.records[].a` | Object | No | Value for an `A` record. Exactly one type-specific field should be set matching RecordType. |
+| `spec.records[].a.content` | string | Yes* | The record value. Required when the `a` object is set. |
+| `spec.records[].aaaa` | Object | No | Value for an `AAAA` record. |
+| `spec.records[].alias` | Object | No | Value for an ALIAS/ANAME-style record; content is a hostname (FQDN or relative) with an optional trailing dot. |
+| `spec.records[].caa` | Object | No | Value for a `CAA` record. |
+| `spec.records[].cname` | Object | No | Value for a `CNAME` record. |
+| `spec.records[].cname.content` | string | Yes* | The record value. Required when the `cname` object is set. |
+| `spec.records[].https` | Object | No | Value for an `HTTPS` record. |
+| `spec.records[].mx` | Object | No | Value for an `MX` record. |
+| `spec.records[].ns` | Object | No | Value for an `NS` record. |
+| `spec.records[].ptr` | Object | No | Value for a `PTR` record. |
+| `spec.records[].soa` | Object | No | Value for an `SOA` record. |
+| `spec.records[].srv` | Object | No | Value for an `SRV` record. |
+| `spec.records[].svcb` | Object | No | Value for an `SVCB` record. |
+| `spec.records[].tlsa` | Object | No | Value for a `TLSA` record. |
+| `spec.records[].txt` | Object | No | Value for a `TXT` record. |
+| `spec.records[].txt.content` | string | Yes* | The record value. Required when the `txt` object is set. |
+
+<Info>
+  Within each entry in `spec.records`, exactly one type-specific object (`a`, `aaaa`, `cname`, `txt`, and so on) should be set, matching `spec.recordType`. Fields marked Yes* are required only when their parent type-specific object is present.
+</Info>
+
+## Status fields (read-only)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status.conditions` | []Object | Includes `Accepted` and `Programmed` readiness. |
+| `status.recordSets` | []Object | Captures per-owner (per name) status and conditions. |
+
+## Usage
+
+```yaml
+apiVersion: dns.networking.miloapis.com/v1alpha1
+kind: DNSRecordSet
+metadata:
+  name: www-a
+spec:
+  dnsZoneRef:
+    name: example-com
+  recordType: A
+  records:
+    - name: www
+      ttl: 300
+      a:
+        content: 203.0.113.10
+```
+
+```bash
+# Apply the recordset
+datumctl apply -f dnsrecordset.yaml --project my-project
+
+# List DNS recordsets in the project
+datumctl get dnsrecordsets --project my-project
+
+# Inspect a specific recordset
+datumctl describe dnsrecordset www-a --project my-project
+```
+
+<Tip>
+  Run `datumctl explain dnsrecordsets --recursive` to see the full, live field tree for this resource.
+</Tip>

--- a/api/dns/dnszone.mdx
+++ b/api/dns/dnszone.mdx
@@ -1,0 +1,64 @@
+---
+title: "DNSZone"
+sidebarTitle: "DNSZone"
+description: "DNSZone is the Schema for the dnszones API."
+---
+
+<Note>
+  API resource reference for **DNSZone**, part of the [DNS service](/api/dns/overview). To create or change one, see [Changing resources](/datumctl/resources/changing); to read or inspect, see [Reading resources](/datumctl/resources/reading). For the underlying concept, see [Domains & DNS](/domain-dns/dns).
+</Note>
+
+<Warning>
+  This resource is part of the `v1alpha1` API and is subject to change. Fields and behavior may change in future releases.
+</Warning>
+
+## Identity
+
+| | |
+| --- | --- |
+| Group | `dns.networking.miloapis.com` |
+| Version | `v1alpha1` |
+| Kind | `DNSZone` |
+| Scope | Project |
+
+## Overview
+
+A `DNSZone` represents an authoritative DNS zone for a fully qualified domain name, provisioned from a referenced `DNSZoneClass`. Use it to establish the zone (for example, `example.com`) that DNS record sets are attached to within a Project.
+
+## Spec fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `spec.dnsZoneClassName` | string | Yes | References the DNSZoneClass used to provision this zone. |
+| `spec.domainName` | string | Yes | The FQDN of the zone (e.g., `example.com`). |
+
+## Status fields (read-only)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status.conditions` | []Object | Tracks state such as Accepted and Programmed readiness. |
+| `status.domainRef` | Object | References the Domain this zone belongs to. |
+| `status.nameservers` | []string | Lists the active authoritative nameservers for this zone. |
+| `status.recordCount` | integer | The number of DNSRecordSet resources in this Project that reference this zone. |
+
+## Usage
+
+```yaml
+apiVersion: dns.networking.miloapis.com/v1alpha1
+kind: DNSZone
+metadata:
+  name: example-com
+spec:
+  dnsZoneClassName: standard
+  domainName: example.com
+```
+
+```bash
+datumctl apply -f dnszone.yaml --project my-project
+datumctl get dnszones --project my-project
+datumctl describe dnszone example-com --project my-project
+```
+
+<Tip>
+  Run `datumctl explain dnszones --recursive` to see the full, live field tree for this resource.
+</Tip>

--- a/api/dns/dnszoneclass.mdx
+++ b/api/dns/dnszoneclass.mdx
@@ -1,0 +1,74 @@
+---
+title: "DNSZoneClass"
+sidebarTitle: "DNSZoneClass"
+description: "DNSZoneClass is the Schema for the dnszoneclasses API."
+---
+
+<Note>
+  API resource reference for **DNSZoneClass**, part of the [DNS service](/api/dns/overview). To create or change one, see [Changing resources](/datumctl/resources/changing); to read or inspect, see [Reading resources](/datumctl/resources/reading). For the underlying concept, see [Domains & DNS](/domain-dns/dns).
+</Note>
+
+<Warning>
+  This resource is part of the `v1alpha1` API and is subject to change. Fields and behavior may evolve in future releases.
+</Warning>
+
+## Identity
+
+| | |
+| --- | --- |
+| **Group** | `dns.networking.miloapis.com` |
+| **Version** | `v1alpha1` |
+| **Kind** | `DNSZoneClass` |
+| **Scope** | Platform |
+
+## Overview
+
+A `DNSZoneClass` describes a class of DNS zone: which downstream controller or backend implementation serves the zones that reference it, and the default behavior applied to those zones. You define a `DNSZoneClass` once, at the Platform level, so that individual DNS zones can select a backend (for example, `powerdns` or `hickory`) along with default TTLs and a nameserver-assignment policy.
+
+## Spec fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `spec.controllerName` | string | Yes | Identifies the downstream controller/backend implementation (e.g., `powerdns`, `hickory`). |
+| `spec.defaults` | Object | No | Provides optional default values applied to managed zones. |
+| `spec.defaults.defaultTTL` | integer | No | Default TTL applied to records when not otherwise specified. |
+| `spec.nameServerPolicy` | Object | No | Defines how nameservers are assigned for zones using this class. |
+| `spec.nameServerPolicy.mode` | string | Yes | Which policy to use. Enum: `Static`. |
+| `spec.nameServerPolicy.static` | Object | No | A static list of authoritative nameservers when `mode == "Static"`. |
+| `spec.nameServerPolicy.static.servers` | []string | Yes | The authoritative nameservers. |
+
+<Info>
+  `spec.nameServerPolicy.mode` and `spec.nameServerPolicy.static.servers` are only required when their parent object is present. The single top-level required field is `spec.controllerName`.
+</Info>
+
+## Status fields (read-only)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status.conditions` | []Object | Represent the current state of the resource. Common types include `Accepted` and `Programmed` to standardize readiness reporting across controllers. |
+
+## Usage
+
+```yaml
+apiVersion: dns.networking.miloapis.com/v1alpha1
+kind: DNSZoneClass
+metadata:
+  name: powerdns
+spec:
+  controllerName: powerdns
+```
+
+```bash
+# Create or update the DNSZoneClass
+datumctl apply -f dnszoneclass.yaml
+
+# List all DNSZoneClasses
+datumctl get dnszoneclasses
+
+# Inspect a single DNSZoneClass
+datumctl describe dnszoneclass powerdns
+```
+
+<Tip>
+  Run `datumctl explain dnszoneclasses --recursive` to see the full, live field tree for this resource.
+</Tip>

--- a/api/dns/overview.mdx
+++ b/api/dns/overview.mdx
@@ -1,0 +1,42 @@
+---
+title: "DNS"
+sidebarTitle: "Overview"
+description: "Managed authoritative DNS on Datum Cloud — zones, record sets, and the classes that provision them."
+---
+
+Datum Cloud provides managed authoritative DNS through the `dns.networking.miloapis.com` API. You declare a zone for a domain you control, add the record sets that answer queries for it, and Datum handles provisioning the zone on a backend, assigning nameservers, and publishing your records. Zones and record sets are Project resources you create with `datumctl apply -f`; a Platform-level zone class selects the backend controller and supplies provisioning defaults.
+
+<Warning>
+  The DNS API is **alpha** (`v1alpha1`). Fields and behavior may change in backward-incompatible ways between releases.
+</Warning>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="DNSZone" icon="globe" href="/api/dns/dnszone">
+    A managed zone for a domain (for example `example.com`). Binds a domain name to a zone class and reports its active nameservers.
+  </Card>
+  <Card title="DNSRecordSet" icon="list" href="/api/dns/dnsrecordset">
+    One or more records of a single type (A, AAAA, CNAME, and more) attached to a zone.
+  </Card>
+  <Card title="DNSZoneClass" icon="layer-group" href="/api/dns/dnszoneclass">
+    A Platform resource identifying the backend controller and defaults used to provision zones.
+  </Card>
+</CardGroup>
+
+## How the pieces fit together
+
+- A **DNSZone** references a **DNSZoneClass** by name (`spec.dnsZoneClassName`) and declares the fully qualified `spec.domainName`. Once accepted, its status reports the authoritative `nameservers` you delegate to and a `recordCount`.
+- A **DNSRecordSet** references its **DNSZone** (`spec.dnsZoneRef`), sets a `spec.recordType`, and carries one or more `spec.records`. Its status tracks per-owner readiness.
+- A **DNSZoneClass** identifies the downstream `spec.controllerName` (for example `powerdns`) and can supply `spec.defaults` and a `spec.nameServerPolicy` applied to zones that use it.
+
+<Tip>
+  Inspect the exact fields for any resource with `datumctl explain`, for example `datumctl explain dnszones.spec` or `datumctl explain dnsrecordsets.spec`.
+</Tip>
+
+## Learn more
+
+- [API resources overview](/api/overview) — the resource reference landing page across all Datum Cloud services.
+- [Domains & DNS](/domain-dns/dns) — concepts behind managing domains and DNS on Datum Cloud.
+- [Changing resources](/datumctl/resources/changing) — how to apply, edit, and safely preview changes to these resources.
+- [Reading resources](/datumctl/resources/reading) — how to list, get, and inspect these resources with `datumctl`.

--- a/api/networking/domain.mdx
+++ b/api/networking/domain.mdx
@@ -1,0 +1,69 @@
+---
+title: "Domain"
+sidebarTitle: "Domain"
+description: "Domain represents a domain name in the Datum system."
+---
+
+<Note>
+  API resource reference for **Domain**, part of the [Networking service](/api/networking/overview). To create or change one, see [Changing resources](/datumctl/resources/changing); to read or inspect, see [Reading resources](/datumctl/resources/reading). For the underlying concept, see [Domains & DNS](/domain-dns/dns).
+</Note>
+
+<Warning>
+  The `networking.datumapis.com/v1alpha` API is **alpha** and subject to change. Fields and behavior may change in future releases.
+</Warning>
+
+## Identity
+
+| | |
+| --- | --- |
+| Group | `networking.datumapis.com` |
+| Version | `v1alpha` |
+| Kind | `Domain` |
+| Scope | Project |
+
+## Overview
+
+A `Domain` represents a fully qualified domain name (FQDN) that Datum Cloud manages on your behalf. You create a `Domain` to bring a domain under management so that Datum can track its registration and verification status and discover its authoritative nameservers. Each `Domain` lives in a Project.
+
+## Spec fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `spec.domainName` | string | Yes | The fully qualified domain name (FQDN) to be managed. |
+| `spec.desiredRegistrationRefreshAttempt` | string | No | The desired time of the next registration refresh attempt. |
+
+## Status fields (read-only)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status.apex` | boolean | True when `spec.domainName` is the registered domain (eTLD+1). |
+| `status.conditions` | []Object | Conditions describing the current state of the Domain. |
+| `status.nameservers` | []Object | The authoritative NS for the effective domain name. If `apex` is true, taken from RDAP for the registered domain (eTLD+1); if false, taken from DNS delegation for the subdomain, falling back to apex NS if there is no cut. |
+| `status.registration` | Object | Registration information for the domain. |
+| `status.verification` | Object | Verification status of the domain. |
+
+## Usage
+
+```yaml
+apiVersion: networking.datumapis.com/v1alpha
+kind: Domain
+metadata:
+  name: example-com
+spec:
+  domainName: example.com
+```
+
+```bash
+# Create or update the Domain
+datumctl apply -f domain.yaml --project my-project
+
+# List Domains in the project
+datumctl get domains --project my-project
+
+# Inspect a single Domain
+datumctl describe domain example-com --project my-project
+```
+
+<Tip>
+  Run `datumctl explain domains --recursive` to see the full, live field tree for this resource.
+</Tip>

--- a/api/networking/httpproxy.mdx
+++ b/api/networking/httpproxy.mdx
@@ -1,0 +1,77 @@
+---
+title: "HTTPProxy"
+sidebarTitle: "HTTPProxy"
+description: "An HTTPProxy provides a convenient way to manage simple reverse proxy use cases."
+---
+
+<Note>
+  API resource reference for **HTTPProxy**, part of the [Networking service](/api/networking/overview). To create or change one, see [Changing resources](/datumctl/resources/changing); to read or inspect, see [Reading resources](/datumctl/resources/reading).
+</Note>
+
+<Warning>
+  HTTPProxy is an **alpha** API (`v1alpha`) and is subject to change. Fields and behavior may change in future releases.
+</Warning>
+
+## Identity
+
+| | |
+| --- | --- |
+| **Group** | `networking.datumapis.com` |
+| **Version** | `v1alpha` |
+| **Kind** | `HTTPProxy` |
+| **Scope** | Project |
+
+## Overview
+
+An HTTPProxy builds on top of Gateway API resources to provide a more convenient way to manage simple reverse proxy use cases. You define a set of hostnames to match against the incoming HTTP `Host` header along with routing rules that match, filter, and forward requests to backends. Use it when you want to expose one or more backends behind a stable, platform-managed hostname without configuring the underlying gateway resources directly.
+
+## Spec fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `spec.hostnames` | []string | No | Hostnames that should match against the HTTP `Host` header to select this HTTPProxy. Values follow RFC 1123 (IPs and wildcards are not allowed). Hostnames must be verified via `Domain` resources and must be unique across the platform; unverified or conflicting hostnames are reported on the `HostnamesVerified` condition. |
+| `spec.rules` | []Object | Yes | A list of HTTP matchers, filters, and actions. Each rule matches an HTTP request based on conditions, processes it, and forwards it to backends. |
+| `spec.rules[].name` | string | No | Name of the route rule. Must be unique within the HTTPProxy if set. |
+| `spec.rules[].matches` | []Object | No | Conditions used for matching the rule against incoming HTTP requests. Each match is independent — the rule matches if **any** one of the matches is satisfied. |
+| `spec.rules[].filters` | []Object | No | Filters applied to requests that match this rule. |
+| `spec.rules[].backends` | []Object | No | Backend(s) where matching requests should be sent. Only a single element is permitted at this time. |
+| `spec.rules[].backends[].endpoint` | string | Yes | Endpoint for the backend. Must be a valid URL. Supports `http` and `https`, IP or DNS hosts, custom ports, and paths. |
+| `spec.rules[].backends[].connector` | Object | No | References the Connector that should be used for this backend. Only a name reference is supported for now. |
+| `spec.rules[].backends[].filters` | []Object | No | Filters executed if and only if the request is forwarded to this backend. |
+| `spec.rules[].backends[].tls` | Object | No | Backend TLS configuration. When the backend endpoint uses HTTPS with an IP address, the hostname must be specified for TLS certificate validation. |
+
+## Status fields (read-only)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status.addresses` | []Object | Network addresses that have been bound to the HTTPProxy. Does not contain custom hostnames — see the `hostnames` field. |
+| `status.canonicalHostname` | string | Platform-managed stable hostname assigned to this HTTPProxy (e.g. `<uid>.datumproxy.net`). Create external CNAME or ALIAS records pointing at this hostname to route traffic through the platform. |
+| `status.conditions` | []Object | Current conditions of the HTTPProxy. |
+| `status.hostnameStatuses` | []Object | Per-hostname status for each configured hostname, including verification and DNS record programming conditions. Use this instead of the deprecated `hostnames` field for detailed per-hostname lifecycle information. |
+| `status.hostnames` | []string | Hostnames that have been bound to the HTTPProxy. Deprecated: use `hostnameStatuses` for detailed per-hostname status; this field will be removed in a future API version. |
+
+## Usage
+
+```yaml
+apiVersion: networking.datumapis.com/v1alpha
+kind: HTTPProxy
+metadata:
+  name: example-proxy
+spec:
+  hostnames:
+    - app.example.com
+  rules:
+    - name: default
+      backends:
+        - endpoint: https://backend.example.com
+```
+
+```bash
+datumctl apply -f httpproxy.yaml --project my-project
+datumctl get httpproxies --project my-project
+datumctl describe httpproxy example-proxy --project my-project
+```
+
+<Tip>
+  Run `datumctl explain httpproxies --recursive` for the full, live field tree.
+</Tip>

--- a/api/networking/network.mdx
+++ b/api/networking/network.mdx
@@ -1,0 +1,70 @@
+---
+title: "Network"
+sidebarTitle: "Network"
+description: "Network is the Schema for the networks API."
+---
+
+<Note>
+  API resource reference for **Network**, part of the [Networking service](/api/networking/overview). To create or change one, see [Changing resources](/datumctl/resources/changing); to read or inspect, see [Reading resources](/datumctl/resources/reading).
+</Note>
+
+<Warning>
+  The `networking.datumapis.com/v1alpha` API is **alpha** and subject to change. Fields and behavior may change in future releases.
+</Warning>
+
+## Identity
+
+| | |
+| --- | --- |
+| **Group** | `networking.datumapis.com` |
+| **Version** | `v1alpha` |
+| **Kind** | `Network` |
+| **Scope** | Project |
+
+## Overview
+
+A Network defines a connectivity fabric within a Datum Cloud project. You use it to establish the IP addressing plan for your workloads — choosing which IP families are permitted, how addresses are allocated (IPAM), and the network MTU. Create a Network when you need a dedicated addressable space for the resources in a project.
+
+## Spec fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `spec.ipFamilies` | `[]string` | No | IP families to permit on a network. Defaults to IPv4. |
+| `spec.ipam` | `Object` | Yes | IPAM settings for the network. |
+| `spec.ipam.ipv4Range` | `string` | No | IPv4 range to use in auto mode networks. Defaults to `10.128.0.0/9`. |
+| `spec.ipam.ipv6Range` | `string` | No | IPv6 range to use in auto mode networks. Defaults to a `/48` allocated from `fd20::/20`. |
+| `spec.ipam.mode` | `string` | Yes | IPAM mode. One of `Auto`, `Policy`. |
+| `spec.mtu` | `integer` | No | Network MTU. May be between 1300 and 8856. |
+
+## Status fields (read-only)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status.conditions` | `[]Object` | Represents the observations of a network's current state. |
+
+## Usage
+
+```yaml
+apiVersion: networking.datumapis.com/v1alpha
+kind: Network
+metadata:
+  name: my-network
+spec:
+  ipam:
+    mode: Auto
+```
+
+```bash
+# Apply the manifest
+datumctl apply -f network.yaml --project my-project
+
+# List networks in the project
+datumctl get networks --project my-project
+
+# Inspect a single network
+datumctl describe network my-network --project my-project
+```
+
+<Tip>
+  Run `datumctl explain networks --recursive` to see the full, live field tree for this resource.
+</Tip>

--- a/api/networking/overview.mdx
+++ b/api/networking/overview.mdx
@@ -1,0 +1,39 @@
+---
+title: "Networking"
+sidebarTitle: "Overview"
+description: "API reference for the networking.datumapis.com service — networks, subnets, HTTP proxies, and domains on Datum Cloud."
+---
+
+Datum Cloud networking lets you define and connect the infrastructure your applications run on. The `networking.datumapis.com` service groups the resources that describe your network topology and how traffic reaches your services: private [Networks](/api/networking/network) with their addressing, the [Subnets](/api/networking/subnet) carved out of them, [HTTPProxies](/api/networking/httpproxy) that expose services over HTTP, and the [Domains](/api/networking/domain) that name them. You create and update these resources declaratively with `datumctl apply -f`, and inspect them with `datumctl get` and `datumctl describe`.
+
+<Warning>
+  These resources are **alpha** (`v1alpha`). The API surface — fields, defaults, and behavior — may change in backward-incompatible ways between releases.
+</Warning>
+
+## Piloted resources
+
+This reference documents a pilot subset of the networking service. More resources exist in `networking.datumapis.com`; the pages below cover the ones available in the pilot.
+
+<CardGroup cols={2}>
+  <Card title="Network" icon="network-wired" href="/api/networking/network">
+    Define a private network with its IP families, address management, and MTU.
+  </Card>
+  <Card title="Subnet" icon="sitemap" href="/api/networking/subnet">
+    Carve an addressable range out of a network.
+  </Card>
+  <Card title="HTTPProxy" icon="globe" href="/api/networking/httpproxy">
+    Expose a service over HTTP with a convenient reverse-proxy configuration.
+  </Card>
+  <Card title="Domain" icon="tag" href="/api/networking/domain">
+    Register a domain name in Datum for use by other networking resources.
+  </Card>
+</CardGroup>
+
+<Tip>
+  New to editing Datum resources? See [Changing resources](/datumctl/resources/changing) for how to apply, edit, and safely preview changes with `datumctl`.
+</Tip>
+
+## Learn more
+
+- [API resources overview](/api/overview) — the resource reference landing page across all Datum Cloud services.
+- [Reading resources](/datumctl/resources/reading) — how to list, get, and inspect these resources with `datumctl`.

--- a/api/networking/subnet.mdx
+++ b/api/networking/subnet.mdx
@@ -1,0 +1,82 @@
+---
+title: "Subnet"
+sidebarTitle: "Subnet"
+description: "Subnet is the Schema for the subnets API."
+---
+
+<Note>
+  API resource reference for **Subnet**, part of the [Networking service](/api/networking/overview). To create or change one, see [Changing resources](/datumctl/resources/changing); to read or inspect, see [Reading resources](/datumctl/resources/reading).
+</Note>
+
+<Warning>
+  This resource is part of an **alpha** API (`v1alpha`). Its fields and behavior are subject to change.
+</Warning>
+
+## Identity
+
+| | |
+| --- | --- |
+| **Group** | `networking.datumapis.com` |
+| **Version** | `v1alpha` |
+| **Kind** | `Subnet` |
+| **Scope** | Project |
+
+## Overview
+
+A `Subnet` defines a range of IP addresses within a network context at a specific location. You create one to allocate addressing for a network, specifying the IP family, subnet class, start address, and prefix length. Once created, Datum Cloud tracks the subnet's allocated address range in its status.
+
+## Spec fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `spec.ipFamily` | string | Yes | The IP family of a subnet. One of `IPv4`, `IPv6`. |
+| `spec.location` | Object | Yes | The location which a subnet is associated with. |
+| `spec.location.name` | string | Yes | Name of a datum location. |
+| `spec.location.namespace` | string | Yes | Namespace for the datum location. |
+| `spec.networkContext` | Object | Yes | A subnet's network context. |
+| `spec.networkContext.name` | string | Yes | The network context name. |
+| `spec.prefixLength` | integer | Yes | The prefix length of a subnet. |
+| `spec.startAddress` | string | Yes | The start address of a subnet. |
+| `spec.subnetClass` | string | Yes | The class of subnet. |
+
+## Status fields (read-only)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status.conditions` | []Object | Represents the observations of a subnet's current state. |
+| `status.prefixLength` | integer | The prefix length of a subnet. |
+| `status.startAddress` | string | The start address of a subnet. |
+
+## Usage
+
+```yaml
+apiVersion: networking.datumapis.com/v1alpha
+kind: Subnet
+metadata:
+  name: my-subnet
+spec:
+  ipFamily: IPv4
+  subnetClass: private
+  startAddress: "10.0.0.0"
+  prefixLength: 24
+  location:
+    name: my-location
+    namespace: my-project
+  networkContext:
+    name: my-network-context
+```
+
+```bash
+# Create or update the subnet
+datumctl apply -f subnet.yaml --project my-project
+
+# List subnets in the project
+datumctl get subnets --project my-project
+
+# Inspect a single subnet
+datumctl describe subnet my-subnet --project my-project
+```
+
+<Tip>
+  Run `datumctl explain subnets --recursive` to see the full, live field tree for this resource.
+</Tip>

--- a/api/overview.mdx
+++ b/api/overview.mdx
@@ -1,0 +1,53 @@
+---
+title: "API resources"
+sidebarTitle: "Overview"
+description: "The resource and field reference for Datum Cloud services."
+---
+
+This section is the **resource and field reference** for Datum Cloud. It documents the resources each service exposes and the fields you set and read on them — what a resource *is*, not how to accomplish a task with it.
+
+<Info>
+  Looking for how-to guides or the CLI command list instead? Here's how the three references fit together:
+
+  - **API resources** (you are here) — the resource/field reference: what fields a resource has, their types, and what they mean.
+  - **[datumctl](/datumctl/overview)** — task-oriented how-to guides for using the CLI.
+  - **[CLI Commands](/cli/options)** — the command and flag reference for `datumctl`.
+</Info>
+
+<Warning>
+  The Datum Cloud API is currently **alpha** (`v1alpha`/`v1alpha1`). Resources, fields, and defaults may change in backward-incompatible ways between releases.
+</Warning>
+
+## Browse by service
+
+Resources are organized by the service that owns them.
+
+<CardGroup cols={2}>
+  <Card title="DNS" icon="globe" href="/api/dns/overview">
+    Managed DNS zones and records for your domains.
+  </Card>
+  <Card title="Networking" icon="network-wired" href="/api/networking/overview">
+    Networks, gateways, and connectivity resources.
+  </Card>
+</CardGroup>
+
+## How to read these pages
+
+Each resource page follows the same structure:
+
+- **Identity** — the resource's kind, API group and version, and scope. Scope is either **Project** (the resource lives inside a project) or **Platform** (the resource is shared across the platform).
+- **Spec fields** — the fields you set to declare the resource's desired state. Fields marked *Required* must be supplied; everything else is optional.
+- **Status** — the fields the platform populates to report observed state. These are read-only.
+- **Usage** — how to create, read, and inspect the resource with `datumctl`.
+
+Manifests are applied with `datumctl apply -f`, and you can read or inspect resources with `datumctl get` and `datumctl describe`.
+
+```bash
+datumctl apply -f my-resource.yaml
+datumctl get <resource>
+datumctl describe <resource> <name>
+```
+
+<Tip>
+  Field types and required markers throughout this reference come straight from the live API schema, which you can also explore from the CLI with `datumctl explain`.
+</Tip>

--- a/docs.json
+++ b/docs.json
@@ -264,6 +264,37 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "API resources",
+        "icon": "boxes-stacked",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "api/overview"
+            ]
+          },
+          {
+            "group": "DNS",
+            "pages": [
+              "api/dns/overview",
+              "api/dns/dnszone",
+              "api/dns/dnsrecordset",
+              "api/dns/dnszoneclass"
+            ]
+          },
+          {
+            "group": "Networking",
+            "pages": [
+              "api/networking/overview",
+              "api/networking/network",
+              "api/networking/subnet",
+              "api/networking/httpproxy",
+              "api/networking/domain"
+            ]
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
A **pilot** of a new top-level **API resources** tab — a resource/field reference for Datum Cloud services — to validate the page design and navigation before investing in a full generator.

## Scope of this pilot
Two services from the recommended user-facing allow-list:
- **DNS** — DNSZone, DNSRecordSet, DNSZoneClass
- **Networking** — Network, Subnet, HTTPProxy, Domain

Plus a tab landing page and per-service overviews.

## How it was built
Each resource page's **spec/status field tables were generated from the live API schema** (captured via `datumctl explain`), so fields, types, required markers, and descriptions are exact — not hand-written. Verified: every documented spec field matches the schema, with no invented or missing fields.

## Page design (what we're validating)
Identity (Group/Version/Kind/**Scope** as Project/Platform), Overview, Spec fields table, read-only Status table, and a Usage section with a real manifest + `datumctl apply/get/describe`. An alpha warning appears on every resource (all groups are `v1alpha`/`v1alpha1`). No kubectl/CRD framing.

## Boundaries
This tab answers "what fields does a resource have?" — distinct from **datumctl (CLI)** (how-to guides) and **CLI Commands** (verb/flag reference).

## Not in this pilot (next steps if the design lands)
- The full allow-listed service set (~13 services / ~80 resources).
- An OpenAPI-driven **generator** in the datumctl repo to produce and maintain the pages in CI (see the investigation proposal).

> Stacked on `docs/datumctl-plugins` so cross-links to the datumctl guides resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)